### PR TITLE
Add MAINTAINER deprecation rule

### DIFF
--- a/docs/rules/DL3007.md
+++ b/docs/rules/DL3007.md
@@ -1,0 +1,3 @@
+# DL3007 - Avoid latest tag
+
+FROM instructions should specify a version or digest instead of relying on the implicit or `latest` tag. Pinning image versions ensures reproducible builds.

--- a/docs/rules/DL4000.md
+++ b/docs/rules/DL4000.md
@@ -1,0 +1,3 @@
+# DL4000 - MAINTAINER is deprecated
+
+The `MAINTAINER` instruction is obsolete. Replace it with a `LABEL maintainer="name"` directive to declare the image author.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,0 +1,6 @@
+# Lint Rules
+
+The following Hadolint-compatible rules are implemented:
+
+- [DL3007](DL3007.md) - Avoid using implicit or `latest` tags.
+- [DL4000](DL4000.md) - `MAINTAINER` is deprecated. Use `LABEL maintainer` instead.

--- a/internal/ir/document.go
+++ b/internal/ir/document.go
@@ -14,6 +14,7 @@ import (
 type Document struct {
 	Filepath string
 	Stages   []*Stage
+	AST      *parser.Node
 }
 
 // Stage represents a single FROM instruction.
@@ -30,7 +31,7 @@ type Stage struct {
 //
 // BuildDocument iterates the AST, collecting FROM instructions as stages.
 func BuildDocument(path string, ast *parser.Node) (*Document, error) {
-	doc := &Document{Filepath: path}
+	doc := &Document{Filepath: path, AST: ast}
 	idx := 0
 	for _, n := range ast.Children {
 		if strings.EqualFold(n.Value, "from") {

--- a/internal/rules/deprecated_maintainer.go
+++ b/internal/rules/deprecated_maintainer.go
@@ -1,0 +1,39 @@
+// file: internal/rules/deprecated_maintainer.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// deprecatedMaintainer flags usage of the deprecated MAINTAINER instruction.
+type deprecatedMaintainer struct{}
+
+// NewDeprecatedMaintainer constructs the rule.
+func NewDeprecatedMaintainer() engine.Rule { return deprecatedMaintainer{} }
+
+// ID returns the rule identifier.
+func (deprecatedMaintainer) ID() string { return "DL4000" }
+
+// Check scans the AST for MAINTAINER instructions.
+func (deprecatedMaintainer) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if strings.EqualFold(n.Value, "maintainer") {
+			line := n.StartLine
+			findings = append(findings, engine.Finding{
+				RuleID:  "DL4000",
+				Message: "MAINTAINER is deprecated. Use LABEL maintainer=\"name\" instead.",
+				Line:    line,
+			})
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/deprecated_maintainer_test.go
+++ b/internal/rules/deprecated_maintainer_test.go
@@ -1,0 +1,59 @@
+// file: internal/rules/deprecated_maintainer_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+func TestDeprecatedMaintainerID(t *testing.T) {
+	if NewDeprecatedMaintainer().ID() != "DL4000" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+func TestDeprecatedMaintainerViolation(t *testing.T) {
+	src := "FROM alpine\nMAINTAINER Somebody\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewDeprecatedMaintainer()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 || findings[0].Line != 2 {
+		t.Fatalf("expected one finding on line 2, got %#v", findings)
+	}
+}
+
+func TestDeprecatedMaintainerClean(t *testing.T) {
+	src := "FROM alpine\nLABEL maintainer=\"Somebody\"\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewDeprecatedMaintainer()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}


### PR DESCRIPTION
## Summary
- track Dockerfile AST in IR Document
- add DL4000 rule to warn about deprecated `MAINTAINER`
- document lint rules

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689e9148f6a083328e6a92a956e9388e