### PR TITLE
Add Makefile with lint, test, and build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+# Copyright (c) 2025 Asymmetric Effort, LLC
+
+.PHONY: lint test build
+
+## Run golangci-lint to lint the codebase
+lint:
+	golangci-lint run
+
+## Run unit and integration tests with coverage
+## Ensures integration coverage is at least 80%
+test:
+	go test ./... -short -cover
+	go test ./... -run Integration -covermode=atomic -coverpkg=./... -coverprofile=coverage.out
+	go tool cover -func=coverage.out | awk '/total:/ { print; if ($3+0 < 80) exit 1 }'
+
+## Build the docker-lint binary
+build:
+	go build -trimpath -ldflags "-s -w" ./cmd/docker-lint


### PR DESCRIPTION
## Summary
- add Makefile with targets for linting, testing, and building the project

## Testing
- `golangci-lint run` *(fails: Error return value of `f.Close` is not checked)*
- `go test ./... -short -cover`
- `go test ./... -run Integration -covermode=atomic -coverpkg=./... -coverprofile=coverage.out`
- `go tool cover -func=coverage.out | awk '/total:/ { print; if ($3+0 < 80) exit 1 }'`


------
https://chatgpt.com/codex/tasks/task_b_689e913156488332b2b196c30caace8f