### PR TITLE
Add benchmark test for document building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ lint:
 test:
 	go test ./... -short -cover
 	go test ./... -run Integration -covermode=atomic -coverpkg=./... -coverprofile=coverage.out
-	go tool cover -func=coverage.out | awk '/total:/ { print; if ($3+0 < 80) exit 1 }'
+	go tool cover -func=coverage.out | awk '/total:/ { print; if ($$3+0 < 80) exit 1 }'
+	go test -run=^$$ -bench=. ./...
 
 ## Build the docker-lint binary
 build:

--- a/internal/ir/document_benchmark_test.go
+++ b/internal/ir/document_benchmark_test.go
@@ -1,0 +1,27 @@
+// file: internal/ir/document_benchmark_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package ir
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+)
+
+// BenchmarkBuildDocument measures the performance of building a Document
+// from a parsed Dockerfile AST.
+func BenchmarkBuildDocument(b *testing.B) {
+	src := "FROM alpine AS base\nRUN echo hi\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		b.Fatalf("parse failed: %v", err)
+	}
+	ast := res.AST
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := BuildDocument("Dockerfile", ast); err != nil {
+			b.Fatalf("build document: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add BenchmarkBuildDocument to measure Document creation performance
- run benchmarks in `make test` alongside coverage checks

## Testing
- `go test ./... -short`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_689e9df4b3508332b63afe960f731ab6