### PR TITLE
Add help flag to CLI

### DIFF
--- a/cmd/docker-lint/main.go
+++ b/cmd/docker-lint/main.go
@@ -16,6 +16,14 @@ import (
 	"github.com/asymmetric-effort/docker-lint/internal/rules"
 )
 
+// usageText describes the command line usage for the application.
+const usageText = "usage: docker-lint <Dockerfile>"
+
+// printUsage writes the CLI usage information to the provided writer.
+func printUsage(out io.Writer) {
+	fmt.Fprintln(out, usageText)
+}
+
 // main is the CLI entry point.
 func main() {
 	if err := run(os.Args[1:], os.Stdout); err != nil {
@@ -27,7 +35,11 @@ func main() {
 // run executes the linter for the provided arguments and writes JSON findings.
 func run(args []string, out io.Writer) error {
 	if len(args) < 1 {
-		return fmt.Errorf("usage: docker-lint <Dockerfile>")
+		return fmt.Errorf(usageText)
+	}
+	if args[0] == "-h" || args[0] == "--help" {
+		printUsage(out)
+		return nil
 	}
 	f, err := os.Open(args[0])
 	if err != nil {

--- a/cmd/docker-lint/main_integration_test.go
+++ b/cmd/docker-lint/main_integration_test.go
@@ -56,6 +56,28 @@ func TestIntegrationRunNoArgs(t *testing.T) {
 	}
 }
 
+// TestIntegrationRunHelpShort verifies that run prints usage when the -h flag is provided.
+func TestIntegrationRunHelpShort(t *testing.T) {
+	var out bytes.Buffer
+	if err := run([]string{"-h"}, &out); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !strings.Contains(out.String(), "usage: docker-lint") {
+		t.Fatalf("expected usage message, got %q", out.String())
+	}
+}
+
+// TestIntegrationRunHelpLong verifies that run prints usage when the --help flag is provided.
+func TestIntegrationRunHelpLong(t *testing.T) {
+	var out bytes.Buffer
+	if err := run([]string{"--help"}, &out); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !strings.Contains(out.String(), "usage: docker-lint") {
+		t.Fatalf("expected usage message, got %q", out.String())
+	}
+}
+
 // TestIntegrationRunMissingFile verifies that run returns an error when the Dockerfile is missing.
 func TestIntegrationRunMissingFile(t *testing.T) {
 	var out bytes.Buffer


### PR DESCRIPTION
## Summary
- Print usage text when invoked with -h or --help
- Add tests verifying help flag handling

## Testing
- `go test ./cmd/docker-lint -run Help -count=1`
- `go test ./... -count=1`


------
https://chatgpt.com/codex/tasks/task_b_689ea3075ab88332ba301607be18f47f