### PR TITLE
docs: document container usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Example output:
 ]
 ```
 
+## Linting Containers
+
+docker-lint is also published as a container image. This allows you to lint Dockerfiles without installing the binary on your host system. Mount your project directory and provide the Dockerfile path inside the container:
+
+```bash
+docker run --rm -v "$(pwd):/src" ghcr.io/asymmetric-effort/docker-lint:latest /src/Dockerfile
+```
+
 ## Development
 
 Common tasks are defined in the [Taskfile](Taskfile.yml). To run them manually:


### PR DESCRIPTION
## Summary
- document running docker-lint as a container image

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689ea3017a308332a2d72b7f0c10e8e5