### PR TITLE
Support glob patterns in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ go install github.com/asymmetric-effort/docker-lint/cmd/docker-lint@latest
 
 ## Usage
 
-Provide the path to a Dockerfile. Findings are emitted as a JSON array to standard output.
+Provide one or more paths or glob patterns (supports `*` and `**`). Matching files are linted and findings are emitted as a JSON array to standard output.
 
 ```bash
 docker-lint /path/to/Dockerfile
+docker-lint './**/Dockerfile'
 ```
 
 Example output:

--- a/cmd/docker-lint/main.go
+++ b/cmd/docker-lint/main.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 
+	doublestar "github.com/bmatcuk/doublestar/v4"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
 	"github.com/asymmetric-effort/docker-lint/internal/engine"
@@ -27,24 +28,10 @@ func main() {
 // run executes the linter for the provided arguments and writes JSON findings.
 func run(args []string, out io.Writer) error {
 	if len(args) < 1 {
-		return fmt.Errorf("usage: docker-lint <Dockerfile>")
+		return fmt.Errorf("usage: docker-lint <file or pattern>")
 	}
-	f, err := os.Open(args[0])
-	if err != nil {
-		return err
-	}
-	defer func(f *os.File) {
-		err := f.Close()
-		if err != nil {
-			fmt.Printf("Error: %s", err.Error())
-		}
-	}(f)
 
-	res, err := parser.Parse(f)
-	if err != nil {
-		return err
-	}
-	doc, err := ir.BuildDocument(args[0], res.AST)
+	files, err := expandPaths(args)
 	if err != nil {
 		return err
 	}
@@ -52,9 +39,53 @@ func run(args []string, out io.Writer) error {
 	reg := engine.NewRegistry()
 	reg.Register(rules.NewNoLatestTag())
 
-	findings, err := reg.Run(context.Background(), doc)
-	if err != nil {
-		return err
+	ctx := context.Background()
+	var all []engine.Finding
+	for _, path := range files {
+		fnds, err := lintFile(ctx, reg, path)
+		if err != nil {
+			return err
+		}
+		all = append(all, fnds...)
 	}
-	return json.NewEncoder(out).Encode(findings)
+	return json.NewEncoder(out).Encode(all)
+}
+
+// expandPaths resolves glob patterns into file paths.
+func expandPaths(patterns []string) ([]string, error) {
+	var files []string
+	for _, p := range patterns {
+		matches, err := doublestar.FilepathGlob(p)
+		if err != nil {
+			return nil, err
+		}
+		if len(matches) == 0 {
+			files = append(files, p)
+			continue
+		}
+		files = append(files, matches...)
+	}
+	return files, nil
+}
+
+// lintFile lints a single Dockerfile and returns any findings.
+func lintFile(ctx context.Context, reg *engine.Registry, path string) (fnds []engine.Finding, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if cerr := f.Close(); err == nil && cerr != nil {
+			err = cerr
+		}
+	}()
+	res, err := parser.Parse(f)
+	if err != nil {
+		return nil, err
+	}
+	doc, err := ir.BuildDocument(path, res.AST)
+	if err != nil {
+		return nil, err
+	}
+	return reg.Run(ctx, doc)
 }

--- a/cmd/docker-lint/main_integration_test.go
+++ b/cmd/docker-lint/main_integration_test.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"errors"
 	"io/fs"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -71,5 +73,80 @@ func TestIntegrationRunInvalidDockerfile(t *testing.T) {
 	var out bytes.Buffer
 	if err := run([]string{df}, &out); err == nil {
 		t.Fatalf("expected parse error, got nil")
+	}
+}
+
+// TestIntegrationRunGlob verifies that run processes files matching single-star patterns.
+func TestIntegrationRunGlob(t *testing.T) {
+	tmp := t.TempDir()
+	goodSrc := testDataPath("Dockerfile.good")
+	badSrc := testDataPath("Dockerfile.bad")
+
+	goodDst := filepath.Join(tmp, "Dockerfile.good")
+	badDst := filepath.Join(tmp, "Dockerfile.bad")
+
+	g, err := os.ReadFile(goodSrc)
+	if err != nil {
+		t.Fatalf("read good: %v", err)
+	}
+	if err := os.WriteFile(goodDst, g, 0o644); err != nil {
+		t.Fatalf("write good: %v", err)
+	}
+	b, err := os.ReadFile(badSrc)
+	if err != nil {
+		t.Fatalf("read bad: %v", err)
+	}
+	if err := os.WriteFile(badDst, b, 0o644); err != nil {
+		t.Fatalf("write bad: %v", err)
+	}
+
+	pattern := filepath.Join(tmp, "Dockerfile.*")
+	var out bytes.Buffer
+	if err := run([]string{pattern}, &out); err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	var findings []engine.Finding
+	if err := json.Unmarshal(out.Bytes(), &findings); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationRunDoubleStar verifies that run processes files matching recursive patterns.
+func TestIntegrationRunDoubleStar(t *testing.T) {
+	tmp := t.TempDir()
+	nested := filepath.Join(tmp, "a", "b")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	badSrc := testDataPath("Dockerfile.bad")
+	rootDst := filepath.Join(tmp, "Dockerfile.bad")
+	nestedDst := filepath.Join(nested, "Dockerfile.bad")
+
+	b, err := os.ReadFile(badSrc)
+	if err != nil {
+		t.Fatalf("read bad: %v", err)
+	}
+	if err := os.WriteFile(rootDst, b, 0o644); err != nil {
+		t.Fatalf("write root: %v", err)
+	}
+	if err := os.WriteFile(nestedDst, b, 0o644); err != nil {
+		t.Fatalf("write nested: %v", err)
+	}
+
+	pattern := filepath.Join(tmp, "**", "Dockerfile.bad")
+	var out bytes.Buffer
+	if err := run([]string{pattern}, &out); err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	var findings []engine.Finding
+	if err := json.Unmarshal(out.Bytes(), &findings); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(findings))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/asymmetric-effort/docker-lint
 
 go 1.24
 
-require github.com/moby/buildkit v0.23.2
+require (
+	github.com/bmatcuk/doublestar/v4 v4.9.1
+	github.com/moby/buildkit v0.23.2
+)
 
 require (
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/avrEXE=
+github.com/bmatcuk/doublestar/v4 v4.9.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/containerd/typeurl/v2 v2.2.3 h1:yNA/94zxWdvYACdYO8zofhrTVuQY73fFU1y++dYSw40=
 github.com/containerd/typeurl/v2 v2.2.3/go.mod h1:95ljDnPfD3bAbDJRugOiShd/DlAAsxGtUBhJxIn7SCk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
## Summary
- expand CLI argument processing to resolve `*` and `**` patterns using `doublestar`
- lint multiple matched Dockerfiles in one run
- document glob usage and add integration tests for single and recursive patterns

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689ea30a39948332bf9348f7752ec213