### PR TITLE
feat: add DL3002 rule

### DIFF
--- a/docs/rules/DL3002.md
+++ b/docs/rules/DL3002.md
@@ -1,0 +1,3 @@
+# DL3002 - Last USER should not be root
+
+The final `USER` instruction in each stage should not specify a root user (`root` or `0`). Use a non-root user to improve container security.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -2,5 +2,6 @@
 
 The following Hadolint-compatible rules are implemented:
 
+- [DL3002](DL3002.md) - Last USER should not be root.
 - [DL3007](DL3007.md) - Avoid using implicit or `latest` tags.
 - [DL4000](DL4000.md) - `MAINTAINER` is deprecated. Use `LABEL maintainer` instead.

--- a/internal/rules/DL3002.go
+++ b/internal/rules/DL3002.go
@@ -1,0 +1,73 @@
+package rules
+
+/*
+ * file: internal/rules/DL3002.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// lastUserNotRoot ensures the final USER in each stage is non-root.
+type lastUserNotRoot struct{}
+
+// NewLastUserNotRoot constructs the rule.
+func NewLastUserNotRoot() engine.Rule { return lastUserNotRoot{} }
+
+// ID returns the rule identifier.
+func (lastUserNotRoot) ID() string { return "DL3002" }
+
+// Check verifies that the last USER instruction per stage is non-root.
+func (lastUserNotRoot) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	children := d.AST.Children
+	for i, stage := range d.Stages {
+		start := -1
+		end := len(children)
+		for idx, n := range children {
+			if n == stage.Node {
+				start = idx
+				break
+			}
+		}
+		if start == -1 {
+			continue
+		}
+		if i+1 < len(d.Stages) {
+			for idx, n := range children {
+				if n == d.Stages[i+1].Node {
+					end = idx
+					break
+				}
+			}
+		}
+		last := ""
+		line := 0
+		for _, n := range children[start+1 : end] {
+			if strings.EqualFold(n.Value, "user") && n.Next != nil {
+				last = n.Next.Value
+				line = n.StartLine
+			}
+		}
+		if last != "" && isRootUser(last) {
+			findings = append(findings, engine.Finding{
+				RuleID:  "DL3002",
+				Message: "Last USER should not be root",
+				Line:    line,
+			})
+		}
+	}
+	return findings, nil
+}
+
+func isRootUser(u string) bool {
+	return u == "root" || u == "0" || strings.HasPrefix(u, "root:") || strings.HasPrefix(u, "0:")
+}

--- a/internal/rules/DL3002_test.go
+++ b/internal/rules/DL3002_test.go
@@ -1,0 +1,73 @@
+// file: internal/rules/DL3002_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationLastUserNotRootID validates rule identity.
+func TestIntegrationLastUserNotRootID(t *testing.T) {
+	if NewLastUserNotRoot().ID() != "DL3002" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationLastUserNotRootViolation detects stages ending with root user.
+func TestIntegrationLastUserNotRootViolation(t *testing.T) {
+	src := "FROM alpine\nUSER root\nRUN echo hi\nFROM busybox\nUSER 0:0\nFROM scratch\nUSER app\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewLastUserNotRoot()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 2 || findings[0].Line != 2 || findings[1].Line != 5 {
+		t.Fatalf("expected findings on lines 2 and 5, got %#v", findings)
+	}
+}
+
+// TestIntegrationLastUserNotRootClean ensures compliant Dockerfiles pass.
+func TestIntegrationLastUserNotRootClean(t *testing.T) {
+	src := "FROM alpine\nUSER root\nUSER app\nRUN echo hi\nFROM busybox\nRUN echo hi\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewLastUserNotRoot()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationLastUserNotRootNilDocument ensures graceful handling of nil input.
+func TestIntegrationLastUserNotRootNilDocument(t *testing.T) {
+	r := NewLastUserNotRoot()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}


### PR DESCRIPTION
## Summary
- implement DL3002 to flag stages whose final USER is root
- document DL3002 and list in rules overview

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689ea3d18c4c8332ab45f4297260eea6