### PR TITLE
Add DL3000 rule for absolute WORKDIR paths

### DIFF
--- a/docs/rules/DL3000.md
+++ b/docs/rules/DL3000.md
@@ -1,0 +1,3 @@
+# DL3000 - Use absolute WORKDIR
+
+WORKDIR paths should be absolute. Relative paths can lead to commands running in unexpected locations. Use absolute paths or environment variables.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -2,5 +2,6 @@
 
 The following Hadolint-compatible rules are implemented:
 
+- [DL3000](DL3000.md) - Use absolute WORKDIR.
 - [DL3007](DL3007.md) - Avoid using implicit or `latest` tags.
 - [DL4000](DL4000.md) - `MAINTAINER` is deprecated. Use `LABEL maintainer` instead.

--- a/internal/rules/DL3000.go
+++ b/internal/rules/DL3000.go
@@ -1,0 +1,64 @@
+package rules
+
+/*
+ * file: internal/rules/DL3000.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+	"unicode"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// absoluteWorkdir ensures WORKDIR uses absolute paths.
+type absoluteWorkdir struct{}
+
+// NewAbsoluteWorkdir constructs the rule.
+func NewAbsoluteWorkdir() engine.Rule { return absoluteWorkdir{} }
+
+// ID returns the rule identifier.
+func (absoluteWorkdir) ID() string { return "DL3000" }
+
+// Check examines WORKDIR instructions for absolute paths.
+func (absoluteWorkdir) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if strings.EqualFold(n.Value, "workdir") {
+			line := n.StartLine
+			path := ""
+			if n.Next != nil {
+				path = n.Next.Value
+			}
+			p := strings.Trim(path, "\"'")
+			if !isAbsoluteWorkdir(p) {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL3000",
+					Message: "Use absolute WORKDIR",
+					Line:    line,
+				})
+			}
+		}
+	}
+	return findings, nil
+}
+
+// isAbsoluteWorkdir reports whether the provided path is absolute or variable-based.
+func isAbsoluteWorkdir(p string) bool {
+	if strings.HasPrefix(p, "$") {
+		return true
+	}
+	if strings.HasPrefix(p, "/") {
+		return true
+	}
+	if len(p) > 1 && unicode.IsLetter(rune(p[0])) && p[1] == ':' {
+		return true
+	}
+	return false
+}

--- a/internal/rules/DL3000_test.go
+++ b/internal/rules/DL3000_test.go
@@ -1,0 +1,115 @@
+// file: internal/rules/DL3000_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationAbsoluteWorkdirID validates rule identity.
+func TestIntegrationAbsoluteWorkdirID(t *testing.T) {
+	if NewAbsoluteWorkdir().ID() != "DL3000" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationAbsoluteWorkdirViolation detects relative WORKDIR usage.
+func TestIntegrationAbsoluteWorkdirViolation(t *testing.T) {
+	src := "FROM alpine\nWORKDIR app\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewAbsoluteWorkdir()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 || findings[0].Line != 2 {
+		t.Fatalf("expected one finding on line 2, got %#v", findings)
+	}
+}
+
+// TestIntegrationAbsoluteWorkdirClean ensures absolute paths pass.
+func TestIntegrationAbsoluteWorkdirClean(t *testing.T) {
+	src := "FROM alpine\nWORKDIR /app\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewAbsoluteWorkdir()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationAbsoluteWorkdirVariable allows variable-based paths.
+func TestIntegrationAbsoluteWorkdirVariable(t *testing.T) {
+	src := "FROM alpine\nWORKDIR $APPDIR\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewAbsoluteWorkdir()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationAbsoluteWorkdirWindows accepts Windows-style paths.
+func TestIntegrationAbsoluteWorkdirWindows(t *testing.T) {
+	src := "FROM alpine\nWORKDIR C:\\\build\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewAbsoluteWorkdir()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationAbsoluteWorkdirNilDocument ensures nil input is handled.
+func TestIntegrationAbsoluteWorkdirNilDocument(t *testing.T) {
+	r := NewAbsoluteWorkdir()
+	if findings, err := r.Check(context.Background(), nil); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", findings, err)
+	}
+	if findings, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", findings, err)
+	}
+}


### PR DESCRIPTION
## Summary
- implement DL3000 to flag relative WORKDIR directives
- document DL3000 rule and list it in rule index

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689ea3b0363c8332ba067d15e8df9b01