### PR TITLE
Add DL1001 rule for inline hadolint ignore pragmas

### DIFF
--- a/docs/rules/DL1001.md
+++ b/docs/rules/DL1001.md
@@ -1,0 +1,3 @@
+# DL1001 - Avoid inline ignore pragmas
+
+Inline `# hadolint ignore=DLxxxx` directives disable lint rules and should be avoided to ensure all checks run.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -2,5 +2,6 @@
 
 The following Hadolint-compatible rules are implemented:
 
+- [DL1001](DL1001.md) - Avoid inline ignore pragmas.
 - [DL3007](DL3007.md) - Avoid using implicit or `latest` tags.
 - [DL4000](DL4000.md) - `MAINTAINER` is deprecated. Use `LABEL maintainer` instead.

--- a/internal/rules/DL1001.go
+++ b/internal/rules/DL1001.go
@@ -1,0 +1,59 @@
+package rules
+
+/*
+ * file: internal/rules/DL1001.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// noInlineIgnore detects inline hadolint ignore pragmas.
+type noInlineIgnore struct{}
+
+// NewNoInlineIgnore constructs the rule.
+func NewNoInlineIgnore() engine.Rule { return noInlineIgnore{} }
+
+// ID returns the rule identifier.
+func (noInlineIgnore) ID() string { return "DL1001" }
+
+// Check scans comments and instructions for hadolint ignore pragmas.
+func (noInlineIgnore) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		for _, com := range n.PrevComment {
+			if hasIgnorePragma(com) {
+				line := n.StartLine
+				if line > 0 {
+					line -= len(n.PrevComment)
+				}
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL1001",
+					Message: "Please refrain from using inline ignore pragmas `# hadolint ignore=DLxxxx`.",
+					Line:    line,
+				})
+			}
+		}
+		if hasIgnorePragma(n.Original) {
+			findings = append(findings, engine.Finding{
+				RuleID:  "DL1001",
+				Message: "Please refrain from using inline ignore pragmas `# hadolint ignore=DLxxxx`.",
+				Line:    n.StartLine,
+			})
+		}
+	}
+	return findings, nil
+}
+
+// hasIgnorePragma reports if the string contains a hadolint ignore pragma.
+func hasIgnorePragma(s string) bool {
+	return strings.Contains(strings.ToLower(s), "hadolint ignore=")
+}

--- a/internal/rules/DL1001_test.go
+++ b/internal/rules/DL1001_test.go
@@ -1,0 +1,62 @@
+// file: internal/rules/DL1001_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationNoInlineIgnoreID validates rule identity.
+func TestIntegrationNoInlineIgnoreID(t *testing.T) {
+	if NewNoInlineIgnore().ID() != "DL1001" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationNoInlineIgnoreViolation reports inline ignore pragmas.
+func TestIntegrationNoInlineIgnoreViolation(t *testing.T) {
+	src := "# hadolint ignore=DL3007\nFROM alpine\nRUN echo hello # hadolint ignore=DL4000\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewNoInlineIgnore()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationNoInlineIgnoreClean ensures files without ignores pass.
+func TestIntegrationNoInlineIgnoreClean(t *testing.T) {
+	src := "FROM alpine\nRUN echo hello\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewNoInlineIgnore()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}


### PR DESCRIPTION
## Summary
- add DL1001 rule to flag `# hadolint ignore=DLxxxx` pragmas
- document DL1001 and list it in rule index
- test inline-ignore detection and clean Dockerfiles

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689ea39014488332a33eded0838e7f76