### PR TITLE
Add hadolint rules DL3003, DL3004, and DL3006

### DIFF
--- a/docs/rules/DL3003.md
+++ b/docs/rules/DL3003.md
@@ -1,0 +1,4 @@
+# DL3003 - Use WORKDIR to switch to a directory
+
+Avoid using `RUN cd` to change directories. Instead, prefer the `WORKDIR`
+instruction to set the working directory for subsequent commands.

--- a/docs/rules/DL3004.md
+++ b/docs/rules/DL3004.md
@@ -1,0 +1,4 @@
+# DL3004 - Do not use sudo
+
+Running `sudo` within containers can cause unpredictable behavior. Use a tool
+like `gosu` to enforce root privileges when required.

--- a/docs/rules/DL3006.md
+++ b/docs/rules/DL3006.md
@@ -1,0 +1,4 @@
+# DL3006 - Always tag the version of an image explicitly
+
+Specify an explicit tag or digest for images in `FROM` instructions. Untagged
+images can lead to unpredictable builds.

--- a/internal/rules/DL3001.go
+++ b/internal/rules/DL3001.go
@@ -6,9 +6,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/google/shlex"
-	"github.com/moby/buildkit/frontend/dockerfile/parser"
-
 	"github.com/asymmetric-effort/docker-lint/internal/engine"
 	"github.com/asymmetric-effort/docker-lint/internal/ir"
 )
@@ -49,37 +46,4 @@ func (noIrrelevantCommands) Check(ctx context.Context, d *ir.Document) ([]engine
 		}
 	}
 	return findings, nil
-}
-
-// extractCommands returns command names invoked in a RUN instruction.
-func extractCommands(n *parser.Node) []string {
-	if n == nil || n.Next == nil {
-		return nil
-	}
-	if n.Attributes != nil && n.Attributes["json"] {
-		return []string{strings.ToLower(n.Next.Value)}
-	}
-	tokens, err := shlex.Split(n.Next.Value)
-	if err != nil {
-		return nil
-	}
-	return commandNames(tokens)
-}
-
-// commandNames identifies command boundaries within shell tokens.
-func commandNames(tokens []string) []string {
-	var cmds []string
-	expect := true
-	for _, tok := range tokens {
-		if expect {
-			cmds = append(cmds, strings.ToLower(tok))
-			expect = false
-			continue
-		}
-		switch tok {
-		case "&&", "||", "|", ";":
-			expect = true
-		}
-	}
-	return cmds
 }

--- a/internal/rules/DL3003.go
+++ b/internal/rules/DL3003.go
@@ -1,0 +1,48 @@
+package rules
+
+/*
+ * file: internal/rules/DL3003.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// useWorkdir enforces using WORKDIR instead of cd in RUN.
+type useWorkdir struct{}
+
+// NewUseWorkdir constructs the rule.
+func NewUseWorkdir() engine.Rule { return useWorkdir{} }
+
+// ID returns the rule identifier.
+func (useWorkdir) ID() string { return "DL3003" }
+
+// Check scans RUN instructions for cd usage.
+func (useWorkdir) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		cmds := extractCommands(n)
+		for _, c := range cmds {
+			if c == "cd" {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL3003",
+					Message: "Use WORKDIR to switch to a directory",
+					Line:    n.StartLine,
+				})
+				break
+			}
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/DL3003_test.go
+++ b/internal/rules/DL3003_test.go
@@ -1,0 +1,73 @@
+// file: internal/rules/DL3003_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationUseWorkdirID validates rule identity.
+func TestIntegrationUseWorkdirID(t *testing.T) {
+	if NewUseWorkdir().ID() != "DL3003" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationUseWorkdirViolation detects cd usage.
+func TestIntegrationUseWorkdirViolation(t *testing.T) {
+	src := "FROM alpine\nRUN cd /tmp\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewUseWorkdir()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationUseWorkdirClean ensures compliant Dockerfiles pass.
+func TestIntegrationUseWorkdirClean(t *testing.T) {
+	src := "FROM alpine\nWORKDIR /tmp\nRUN echo hi\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewUseWorkdir()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationUseWorkdirNilDocument ensures graceful handling of nil input.
+func TestIntegrationUseWorkdirNilDocument(t *testing.T) {
+	r := NewUseWorkdir()
+	if findings, err := r.Check(context.Background(), nil); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", findings, err)
+	}
+	if findings, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", findings, err)
+	}
+}

--- a/internal/rules/DL3004.go
+++ b/internal/rules/DL3004.go
@@ -1,0 +1,48 @@
+package rules
+
+/*
+ * file: internal/rules/DL3004.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// noSudo disallows sudo in RUN instructions.
+type noSudo struct{}
+
+// NewNoSudo constructs the rule.
+func NewNoSudo() engine.Rule { return noSudo{} }
+
+// ID returns the rule identifier.
+func (noSudo) ID() string { return "DL3004" }
+
+// Check scans RUN instructions for sudo usage.
+func (noSudo) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		cmds := extractCommands(n)
+		for _, c := range cmds {
+			if c == "sudo" {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL3004",
+					Message: "Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root",
+					Line:    n.StartLine,
+				})
+				break
+			}
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/DL3004_test.go
+++ b/internal/rules/DL3004_test.go
@@ -1,0 +1,73 @@
+// file: internal/rules/DL3004_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationNoSudoID validates rule identity.
+func TestIntegrationNoSudoID(t *testing.T) {
+	if NewNoSudo().ID() != "DL3004" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationNoSudoViolation detects sudo usage.
+func TestIntegrationNoSudoViolation(t *testing.T) {
+	src := "FROM alpine\nRUN sudo echo hi\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewNoSudo()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationNoSudoClean ensures compliant Dockerfiles pass.
+func TestIntegrationNoSudoClean(t *testing.T) {
+	src := "FROM alpine\nRUN echo hi\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewNoSudo()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationNoSudoNilDocument ensures graceful handling of nil input.
+func TestIntegrationNoSudoNilDocument(t *testing.T) {
+	r := NewNoSudo()
+	if findings, err := r.Check(context.Background(), nil); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", findings, err)
+	}
+	if findings, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", findings, err)
+	}
+}

--- a/internal/rules/DL3006.go
+++ b/internal/rules/DL3006.go
@@ -1,0 +1,75 @@
+package rules
+
+/*
+ * file: internal/rules/DL3006.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// requireTag enforces explicit image tags in FROM instructions.
+type requireTag struct{}
+
+// NewRequireTag constructs the rule.
+func NewRequireTag() engine.Rule { return requireTag{} }
+
+// ID returns the rule identifier.
+func (requireTag) ID() string { return "DL3006" }
+
+// Check examines stage base images for explicit tags.
+func (requireTag) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil {
+		return findings, nil
+	}
+	aliases := map[string]struct{}{}
+	for _, s := range d.Stages {
+		from := s.From
+		if from == "" {
+			if s.Name != "" {
+				aliases[s.Name] = struct{}{}
+			}
+			continue
+		}
+		_, isAlias := aliases[from]
+		if needsTag(from, isAlias) {
+			line := 0
+			if s.Node != nil {
+				line = s.Node.StartLine
+			}
+			findings = append(findings, engine.Finding{
+				RuleID:  "DL3006",
+				Message: "Always tag the version of an image explicitly",
+				Line:    line,
+			})
+		}
+		if s.Name != "" {
+			aliases[s.Name] = struct{}{}
+		}
+	}
+	return findings, nil
+}
+
+// needsTag determines whether the FROM image is missing a tag or digest.
+func needsTag(image string, isAlias bool) bool {
+	if isAlias {
+		return false
+	}
+	if image == "scratch" {
+		return false
+	}
+	if strings.HasPrefix(image, "$") {
+		return false
+	}
+	if strings.Contains(image, "@") {
+		return false
+	}
+	parts := strings.Split(image, ":")
+	return len(parts) == 1
+}

--- a/internal/rules/DL3006_test.go
+++ b/internal/rules/DL3006_test.go
@@ -1,0 +1,72 @@
+// file: internal/rules/DL3006_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationRequireTagID validates rule identity.
+func TestIntegrationRequireTagID(t *testing.T) {
+	if NewRequireTag().ID() != "DL3006" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationRequireTagViolation detects untagged images.
+func TestIntegrationRequireTagViolation(t *testing.T) {
+	r := NewRequireTag()
+	doc := &ir.Document{Stages: []*ir.Stage{{Index: 0, From: "alpine", Node: &parser.Node{StartLine: 1}}}}
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationRequireTagAlias ensures alias references are exempt.
+func TestIntegrationRequireTagAlias(t *testing.T) {
+	r := NewRequireTag()
+	doc := &ir.Document{Stages: []*ir.Stage{
+		{Index: 0, From: "alpine:3.19", Name: "base", Node: &parser.Node{StartLine: 1}},
+		{Index: 1, From: "base", Node: &parser.Node{StartLine: 2}},
+	}}
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationRequireTagClean ensures compliant images pass.
+func TestIntegrationRequireTagClean(t *testing.T) {
+	r := NewRequireTag()
+	doc := &ir.Document{Stages: []*ir.Stage{
+		{Index: 0, From: "alpine:3.19", Node: &parser.Node{StartLine: 1}},
+		{Index: 1, From: "ubuntu@sha256:deadbeef", Node: &parser.Node{StartLine: 2}},
+	}}
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationRequireTagNilDocument ensures graceful handling of nil input.
+func TestIntegrationRequireTagNilDocument(t *testing.T) {
+	r := NewRequireTag()
+	if findings, err := r.Check(context.Background(), nil); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", findings, err)
+	}
+}

--- a/internal/rules/run_commands.go
+++ b/internal/rules/run_commands.go
@@ -1,0 +1,50 @@
+// file: internal/rules/run_commands.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"strings"
+
+	"github.com/google/shlex"
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+)
+
+// extractCommands returns command names invoked in a RUN instruction.
+//
+// extractCommands inspects the RUN node and returns the list of command
+// names, respecting shell parsing and handling JSON-form RUN variants.
+func extractCommands(n *parser.Node) []string {
+	if n == nil || n.Next == nil {
+		return nil
+	}
+	if n.Attributes != nil && n.Attributes["json"] {
+		return []string{strings.ToLower(n.Next.Value)}
+	}
+	tokens, err := shlex.Split(n.Next.Value)
+	if err != nil {
+		return nil
+	}
+	return commandNames(tokens)
+}
+
+// commandNames identifies command boundaries within shell tokens.
+//
+// commandNames returns the ordered list of commands invoked within the
+// tokenized shell statement, tracking boundaries across common shell
+// connectors like && and ||.
+func commandNames(tokens []string) []string {
+	var cmds []string
+	expect := true
+	for _, tok := range tokens {
+		if expect {
+			cmds = append(cmds, strings.ToLower(tok))
+			expect = false
+			continue
+		}
+		switch tok {
+		case "&&", "||", "|", ";":
+			expect = true
+		}
+	}
+	return cmds
+}


### PR DESCRIPTION
## Summary
- enforce using WORKDIR instead of RUN cd (DL3003)
- prohibit sudo usage in RUN commands (DL3004)
- require explicit image tags in FROM instructions (DL3006)
- refactor shared RUN command parsing logic

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689ea6500dfc8332a9315fcd2bbda84b