### PR TITLE
Add DL3008 rule for apt package pinning

### DIFF
--- a/cmd/docker-lint/main.go
+++ b/cmd/docker-lint/main.go
@@ -50,6 +50,7 @@ func run(args []string, out io.Writer) error {
 
 	reg := engine.NewRegistry()
 	reg.Register(rules.NewNoLatestTag())
+	reg.Register(rules.NewAptPin())
 
 	ctx := context.Background()
 	var all []engine.Finding

--- a/docs/rules/DL3008.md
+++ b/docs/rules/DL3008.md
@@ -1,0 +1,2 @@
+# DL3008 - Pin versions in apt-get install
+Ensure all packages installed via apt-get or apt are pinned to a version using `=<version>` to improve build reproducibility.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -6,4 +6,5 @@ The following Hadolint-compatible rules are implemented:
 - [DL3001](DL3001.md) - Avoid irrelevant shell commands like `ssh` or `vim`.
 - [DL3002](DL3002.md) - Last USER should not be root.
 - [DL3007](DL3007.md) - Avoid using implicit or `latest` tags.
+- [DL3008](DL3008.md) - Pin versions in apt-get install.
 - [DL4000](DL4000.md) - `MAINTAINER` is deprecated. Use `LABEL maintainer` instead.

--- a/internal/rules/DL3008.go
+++ b/internal/rules/DL3008.go
@@ -1,0 +1,91 @@
+package rules
+
+/*
+ * file: internal/rules/DL3008.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// aptPin ensures packages installed with apt-get or apt are version pinned.
+type aptPin struct{}
+
+// NewAptPin constructs the rule.
+func NewAptPin() engine.Rule { return aptPin{} }
+
+// ID returns the rule identifier.
+func (aptPin) ID() string { return "DL3008" }
+
+// Check evaluates RUN instructions for unpinned apt installs.
+func (aptPin) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") || n.Next == nil {
+			continue
+		}
+		cmd := n.Next.Value
+		if hasUnpinnedAptInstall(cmd) {
+			findings = append(findings, engine.Finding{
+				RuleID:  "DL3008",
+				Message: "Pin versions in apt-get install. Instead of 'apt-get install <pkg>' use 'apt-get install <pkg>=<version>'.",
+				Line:    n.StartLine,
+			})
+		}
+	}
+	return findings, nil
+}
+
+var splitter = regexp.MustCompile(`\s*(?:&&|\|\||;)\s*`)
+
+func hasUnpinnedAptInstall(cmd string) bool {
+	cmd = strings.ReplaceAll(cmd, "\\\n", " ")
+	cmd = strings.ReplaceAll(cmd, "\n", " ")
+	parts := splitter.Split(cmd, -1)
+	for _, part := range parts {
+		tokens := strings.Fields(part)
+		for i := 0; i < len(tokens); i++ {
+			tok := tokens[i]
+			if tok == "apt-get" || tok == "apt" {
+				for j := i + 1; j < len(tokens); j++ {
+					t := tokens[j]
+					if t == "install" {
+						if unpinnedPackages(tokens[j+1:]) {
+							return true
+						}
+						break
+					}
+					if !strings.HasPrefix(t, "-") {
+						break
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+func unpinnedPackages(args []string) bool {
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") {
+			continue
+		}
+		if !strings.Contains(a, "=") {
+			return true
+		}
+		parts := strings.SplitN(a, "=", 2)
+		if parts[1] == "" || strings.HasPrefix(parts[1], "-") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rules/DL3008_test.go
+++ b/internal/rules/DL3008_test.go
@@ -1,0 +1,62 @@
+// file: internal/rules/DL3008_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationAptPinID validates rule identity.
+func TestIntegrationAptPinID(t *testing.T) {
+	if NewAptPin().ID() != "DL3008" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationAptPinViolation detects unpinned apt installs.
+func TestIntegrationAptPinViolation(t *testing.T) {
+	r := NewAptPin()
+	src := "FROM ubuntu\nRUN apt-get update && apt-get install -y curl ca-certificates\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationAptPinClean ensures compliant installs pass.
+func TestIntegrationAptPinClean(t *testing.T) {
+	r := NewAptPin()
+	src := "FROM ubuntu\nRUN apt-get update && apt-get install -y curl=7.81.0-1 ca-certificates=20240203\nRUN apt install python3=3.10.*\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}


### PR DESCRIPTION
## Summary
- enforce version pinning for packages installed with `apt-get`/`apt`
- document DL3008 rule and update registry

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689ea7e607888332bfccab9c68d19b49