### PR TITLE
feat: enforce apt lists cleanup after APT installs

### DIFF
--- a/cmd/docker-lint/main.go
+++ b/cmd/docker-lint/main.go
@@ -50,6 +50,7 @@ func run(args []string, out io.Writer) error {
 
 	reg := engine.NewRegistry()
 	reg.Register(rules.NewNoLatestTag())
+	reg.Register(rules.NewAptListsCleanup())
 
 	ctx := context.Background()
 	var all []engine.Finding

--- a/docs/rules/DL3009.md
+++ b/docs/rules/DL3009.md
@@ -1,0 +1,3 @@
+# DL3009 - Delete the APT lists after installing packages
+
+Combine `apt-get install` or `apt install` with removal of `/var/lib/apt/lists/*` in the same `RUN` layer to reduce image size and attack surface.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -7,4 +7,5 @@ The following Hadolint-compatible rules are implemented:
 - [DL3001](DL3001.md) - Avoid irrelevant shell commands like `ssh` or `vim`.
 - [DL3002](DL3002.md) - Last USER should not be root.
 - [DL3007](DL3007.md) - Avoid using implicit or `latest` tags.
+- [DL3009](DL3009.md) - Delete the APT lists after installing packages.
 - [DL4000](DL4000.md) - `MAINTAINER` is deprecated. Use `LABEL maintainer` instead.

--- a/internal/rules/DL3009.go
+++ b/internal/rules/DL3009.go
@@ -1,0 +1,138 @@
+package rules
+
+/*
+ * file: internal/rules/DL3009.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+	"github.com/google/shlex"
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+)
+
+// aptListsCleanup ensures apt installs remove package lists in the same layer.
+type aptListsCleanup struct{}
+
+// NewAptListsCleanup constructs the rule.
+func NewAptListsCleanup() engine.Rule { return aptListsCleanup{} }
+
+// ID returns the rule identifier.
+func (aptListsCleanup) ID() string { return "DL3009" }
+
+// Check scans RUN instructions for apt installs lacking cleanup.
+func (aptListsCleanup) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		segments := splitRunSegments(n)
+		if needsAptListsCleanup(segments) {
+			findings = append(findings, engine.Finding{
+				RuleID:  "DL3009",
+				Message: "Delete the APT lists after installing packages.",
+				Line:    n.StartLine,
+			})
+		}
+	}
+	return findings, nil
+}
+
+// splitRunSegments splits a RUN instruction into command segments separated by shell connectors.
+func splitRunSegments(n *parser.Node) [][]string {
+	if n == nil || n.Next == nil {
+		return nil
+	}
+	if n.Attributes != nil && n.Attributes["json"] {
+		return [][]string{{strings.ToLower(n.Next.Value)}}
+	}
+	tokens, err := shlex.Split(n.Next.Value)
+	if err != nil {
+		return nil
+	}
+	var segs [][]string
+	var cur []string
+	for _, tok := range tokens {
+		switch tok {
+		case "&&", "||", ";", "|":
+			if len(cur) > 0 {
+				segs = append(segs, lowerSlice(cur))
+				cur = nil
+			}
+		default:
+			cur = append(cur, tok)
+		}
+	}
+	if len(cur) > 0 {
+		segs = append(segs, lowerSlice(cur))
+	}
+	return segs
+}
+
+// lowerSlice returns a new slice with all elements lowercased.
+func lowerSlice(in []string) []string {
+	out := make([]string, len(in))
+	for i, s := range in {
+		out[i] = strings.ToLower(s)
+	}
+	return out
+}
+
+// needsAptListsCleanup reports whether an apt install occurred without subsequent cleanup.
+func needsAptListsCleanup(segments [][]string) bool {
+	lastInstall := -1
+	lastCleanup := -1
+	for i, seg := range segments {
+		if isAptInstall(seg) {
+			lastInstall = i
+		}
+		if removesAptLists(seg) {
+			lastCleanup = i
+		}
+	}
+	return lastInstall >= 0 && lastCleanup < lastInstall
+}
+
+// isAptInstall reports whether the segment invokes apt-get install or apt install.
+func isAptInstall(seg []string) bool {
+	if len(seg) < 2 {
+		return false
+	}
+	if seg[0] != "apt-get" && seg[0] != "apt" {
+		return false
+	}
+	for _, t := range seg[1:] {
+		if t == "install" {
+			return true
+		}
+	}
+	return false
+}
+
+// removesAptLists reports whether the segment deletes the apt lists directory.
+func removesAptLists(seg []string) bool {
+	if len(seg) == 0 {
+		return false
+	}
+	joined := strings.Join(seg, " ")
+	if !strings.Contains(joined, "/var/lib/apt/lists") {
+		return false
+	}
+	switch seg[0] {
+	case "rm":
+		flags := strings.Join(seg[1:], " ")
+		return strings.Contains(flags, "-rf") || strings.Contains(flags, "-fr") || strings.Contains(flags, "-r")
+	case "find":
+		return strings.Contains(joined, "-delete")
+	default:
+		return false
+	}
+}

--- a/internal/rules/DL3009_test.go
+++ b/internal/rules/DL3009_test.go
@@ -1,0 +1,94 @@
+// file: internal/rules/DL3009_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationAptListsCleanupID validates rule identity.
+func TestIntegrationAptListsCleanupID(t *testing.T) {
+	if NewAptListsCleanup().ID() != "DL3009" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationAptListsCleanupViolation detects missing cleanup after apt install.
+func TestIntegrationAptListsCleanupViolation(t *testing.T) {
+	src := "FROM ubuntu\nRUN apt-get update && apt-get install -y curl\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewAptListsCleanup()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationAptListsCleanupClean ensures cleanup after install passes.
+func TestIntegrationAptListsCleanupClean(t *testing.T) {
+	src := "FROM ubuntu\nRUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewAptListsCleanup()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationAptListsCleanupCleanOnly verifies apt-get clean is insufficient.
+func TestIntegrationAptListsCleanupCleanOnly(t *testing.T) {
+	src := "FROM ubuntu\nRUN apt-get update && apt-get install -y curl && apt-get clean\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewAptListsCleanup()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationAptListsCleanupNil ensures nil documents are handled.
+func TestIntegrationAptListsCleanupNil(t *testing.T) {
+	r := NewAptListsCleanup()
+	if findings, err := r.Check(context.Background(), nil); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", findings, err)
+	}
+	if findings, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", findings, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add DL3009 rule to ensure apt-get/apt installs delete `/var/lib/apt/lists/*`
- document new rule and register it with the linter

## Testing
- `go test ./... -v`


------
https://chatgpt.com/codex/tasks/task_b_689ea899b9048332b3a58cee676400c6