### PR TITLE
Add rule DL3012 for single HEALTHCHECK

### DIFF
--- a/docs/rules/DL3012.md
+++ b/docs/rules/DL3012.md
@@ -1,0 +1,5 @@
+# DL3012 - Multiple HEALTHCHECK instructions
+
+Each stage may include at most one `HEALTHCHECK` instruction. Including
+multiple `HEALTHCHECK` lines can be confusing because only the last one takes
+precedence, potentially masking earlier checks.

--- a/internal/rules/DL3012.go
+++ b/internal/rules/DL3012.go
@@ -1,0 +1,50 @@
+package rules
+
+/*
+ * file: internal/rules/DL3012.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// singleHealthcheck ensures only one HEALTHCHECK instruction per stage.
+type singleHealthcheck struct{}
+
+// NewSingleHealthcheck constructs the rule.
+func NewSingleHealthcheck() engine.Rule { return singleHealthcheck{} }
+
+// ID returns the rule identifier.
+func (singleHealthcheck) ID() string { return "DL3012" }
+
+// Check verifies that each stage contains at most one HEALTHCHECK instruction.
+func (singleHealthcheck) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	seen := false
+	for _, n := range d.AST.Children {
+		if strings.EqualFold(n.Value, "from") {
+			seen = false
+			continue
+		}
+		if strings.EqualFold(n.Value, "healthcheck") {
+			if seen {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL3012",
+					Message: "Multiple HEALTHCHECK instructions",
+					Line:    n.StartLine,
+				})
+			} else {
+				seen = true
+			}
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/DL3012_test.go
+++ b/internal/rules/DL3012_test.go
@@ -1,0 +1,94 @@
+// file: internal/rules/DL3012_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationSingleHealthcheckID validates rule identity.
+func TestIntegrationSingleHealthcheckID(t *testing.T) {
+	if NewSingleHealthcheck().ID() != "DL3012" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationSingleHealthcheckViolation detects multiple healthchecks in a stage.
+func TestIntegrationSingleHealthcheckViolation(t *testing.T) {
+	src := "FROM alpine\nHEALTHCHECK CMD true\nHEALTHCHECK CMD false\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewSingleHealthcheck()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 || findings[0].Line != 3 {
+		t.Fatalf("expected one finding on line 3, got %#v", findings)
+	}
+}
+
+// TestIntegrationSingleHealthcheckClean ensures single healthcheck passes.
+func TestIntegrationSingleHealthcheckClean(t *testing.T) {
+	src := "FROM alpine\nHEALTHCHECK CMD true\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewSingleHealthcheck()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationSingleHealthcheckMultiStage allows one healthcheck per stage.
+func TestIntegrationSingleHealthcheckMultiStage(t *testing.T) {
+	src := "FROM alpine AS base\nHEALTHCHECK CMD true\nFROM scratch\nHEALTHCHECK CMD false\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewSingleHealthcheck()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationSingleHealthcheckNilDocument ensures nil input is handled.
+func TestIntegrationSingleHealthcheckNilDocument(t *testing.T) {
+	r := NewSingleHealthcheck()
+	if findings, err := r.Check(context.Background(), nil); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", findings, err)
+	}
+	if findings, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", findings, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add DL3012 rule enforcing one HEALTHCHECK per stage
- document DL3012
- test DL3012 rule

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689ea9608c988332aff411e87967e87c