### PR TITLE
feat: validate exposed port ranges

### DIFF
--- a/docs/rules/DL3011.md
+++ b/docs/rules/DL3011.md
@@ -1,0 +1,4 @@
+# DL3011 - Valid UNIX ports range from 0 to 65535
+
+Ensure that ports specified in `EXPOSE` instructions fall within the valid range of 0 to 65535.
+

--- a/internal/rules/DL3011.go
+++ b/internal/rules/DL3011.go
@@ -1,0 +1,67 @@
+package rules
+
+/*
+ * file: internal/rules/DL3011.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// validPortRange ensures exposed ports are within valid range.
+type validPortRange struct{}
+
+// NewValidPortRange constructs the rule.
+func NewValidPortRange() engine.Rule { return validPortRange{} }
+
+// ID returns the rule identifier.
+func (validPortRange) ID() string { return "DL3011" }
+
+// Check inspects EXPOSE instructions for invalid ports.
+func (validPortRange) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "expose") {
+			continue
+		}
+		for arg := n.Next; arg != nil; arg = arg.Next {
+			if !portInRange(arg.Value) {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL3011",
+					Message: "Valid UNIX ports range from 0 to 65535",
+					Line:    n.StartLine,
+				})
+				break
+			}
+		}
+	}
+	return findings, nil
+}
+
+// portInRange reports whether all numeric parts of a port token are within 0-65535.
+func portInRange(token string) bool {
+	token = strings.SplitN(token, "/", 2)[0]
+	parts := strings.Split(token, "-")
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		v, err := strconv.Atoi(p)
+		if err != nil {
+			return true
+		}
+		if v < 0 || v > 65535 {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/rules/DL3011_test.go
+++ b/internal/rules/DL3011_test.go
@@ -1,0 +1,73 @@
+// file: internal/rules/DL3011_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationValidPortRangeID validates rule identity.
+func TestIntegrationValidPortRangeID(t *testing.T) {
+	if NewValidPortRange().ID() != "DL3011" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationValidPortRangeViolation detects invalid port declarations.
+func TestIntegrationValidPortRangeViolation(t *testing.T) {
+	src := "FROM alpine\nEXPOSE 80 65536\nEXPOSE 8080-90000/tcp\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewValidPortRange()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 2 || findings[0].Line != 2 || findings[1].Line != 3 {
+		t.Fatalf("expected findings on lines 2 and 3, got %#v", findings)
+	}
+}
+
+// TestIntegrationValidPortRangeClean ensures compliant Dockerfiles pass.
+func TestIntegrationValidPortRangeClean(t *testing.T) {
+	src := "FROM alpine\nEXPOSE 80 443/tcp\nEXPOSE 1000-2000/udp\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewValidPortRange()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationValidPortRangeNilDocument ensures graceful handling of nil input.
+func TestIntegrationValidPortRangeNilDocument(t *testing.T) {
+	r := NewValidPortRange()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add DL3011 rule to flag EXPOSE instructions with ports outside 0-65535
- document DL3011 rule
- cover DL3011 with unit tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689ea94715e48332b75823a001151055