### PR TITLE
feat: enforce apt-get install non-interactive flag

### DIFF
--- a/docs/rules/DL3014.md
+++ b/docs/rules/DL3014.md
@@ -1,0 +1,6 @@
+# DL3014 - Use the -y switch for apt-get install
+
+Include a non-interactive flag when running `apt-get install` in `RUN`
+instructions. Use `-y`, `--yes`, `--assume-yes`, or an equivalent option such as
+`-qq` to avoid manual prompts during package installation.
+

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -7,4 +7,5 @@ The following Hadolint-compatible rules are implemented:
 - [DL3001](DL3001.md) - Avoid irrelevant shell commands like `ssh` or `vim`.
 - [DL3002](DL3002.md) - Last USER should not be root.
 - [DL3007](DL3007.md) - Avoid using implicit or `latest` tags.
+- [DL3014](DL3014.md) - Use the -y switch for apt-get install.
 - [DL4000](DL4000.md) - `MAINTAINER` is deprecated. Use `LABEL maintainer` instead.

--- a/internal/rules/DL3014.go
+++ b/internal/rules/DL3014.go
@@ -1,0 +1,118 @@
+package rules
+
+/*
+ * file: internal/rules/DL3014.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/shlex"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// aptGetYes enforces non-interactive apt-get install invocations.
+type aptGetYes struct{}
+
+// NewAptGetYes constructs the rule.
+func NewAptGetYes() engine.Rule { return aptGetYes{} }
+
+// ID returns the rule identifier.
+func (aptGetYes) ID() string { return "DL3014" }
+
+// Check scans RUN instructions for apt-get install lacking -y or equivalent.
+func (aptGetYes) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		tokens, err := shlex.Split(n.Next.Value)
+		if err != nil {
+			continue
+		}
+		segments := splitByConnectors(tokens)
+		for _, seg := range segments {
+			if isAptGetInstall(seg) && !hasYesOption(seg) {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL3014",
+					Message: "Use the -y switch to avoid manual input apt-get -y install <package>",
+					Line:    n.StartLine,
+				})
+				break
+			}
+		}
+	}
+	return findings, nil
+}
+
+// splitByConnectors divides tokens into command segments.
+func splitByConnectors(tokens []string) [][]string {
+	var segments [][]string
+	var current []string
+	for _, t := range tokens {
+		switch t {
+		case "&&", "||", "|", ";":
+			if len(current) > 0 {
+				segments = append(segments, current)
+				current = nil
+			}
+		default:
+			current = append(current, strings.ToLower(t))
+		}
+	}
+	if len(current) > 0 {
+		segments = append(segments, current)
+	}
+	return segments
+}
+
+// isAptGetInstall reports whether tokens represent `apt-get install`.
+func isAptGetInstall(tokens []string) bool {
+	if len(tokens) == 0 {
+		return false
+	}
+	if tokens[0] != "apt-get" {
+		return false
+	}
+	for _, t := range tokens[1:] {
+		if t == "install" {
+			return true
+		}
+	}
+	return false
+}
+
+// hasYesOption detects non-interactive flags for apt-get.
+func hasYesOption(tokens []string) bool {
+	yesFlags := map[string]struct{}{
+		"-y":           {},
+		"--yes":        {},
+		"--assume-yes": {},
+		"-qq":          {},
+	}
+	qCount := 0
+	quietCount := 0
+	for _, t := range tokens[1:] {
+		if _, ok := yesFlags[t]; ok {
+			return true
+		}
+		if t == "-q=2" || t == "--quiet=2" {
+			return true
+		}
+		if t == "-q" {
+			qCount++
+		}
+		if t == "--quiet" {
+			quietCount++
+		}
+	}
+	return qCount >= 2 || quietCount >= 2
+}

--- a/internal/rules/DL3014_test.go
+++ b/internal/rules/DL3014_test.go
@@ -1,0 +1,94 @@
+// file: internal/rules/DL3014_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationAptGetYesID validates rule identity.
+func TestIntegrationAptGetYesID(t *testing.T) {
+	if NewAptGetYes().ID() != "DL3014" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationAptGetYesViolation detects missing -y in apt-get install.
+func TestIntegrationAptGetYesViolation(t *testing.T) {
+	src := "FROM alpine\nRUN apt-get install curl\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewAptGetYes()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationAptGetYesClean ensures apt-get install -y passes.
+func TestIntegrationAptGetYesClean(t *testing.T) {
+	src := "FROM alpine\nRUN apt-get install -y curl\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewAptGetYes()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationAptGetYesQuiet ensures -qq is treated as non-interactive.
+func TestIntegrationAptGetYesQuiet(t *testing.T) {
+	src := "FROM alpine\nRUN apt-get -qq install curl\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewAptGetYes()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationAptGetYesNilDocument ensures graceful handling of nil input.
+func TestIntegrationAptGetYesNilDocument(t *testing.T) {
+	r := NewAptGetYes()
+	if findings, err := r.Check(context.Background(), nil); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", findings, err)
+	}
+	if findings, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", findings, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add DL3014 rule ensuring `apt-get install` uses a non-interactive flag
- document DL3014 and list it among supported rules

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689ea99cb23c8332b241659758a92967