### PR TITLE
Add DL3013 rule for pinning pip package versions

### DIFF
--- a/docs/rules/DL3013.md
+++ b/docs/rules/DL3013.md
@@ -1,0 +1,3 @@
+# DL3013 - Pin versions in pip
+
+Always pin versions when installing Python packages with `pip` to ensure reproducible builds. Use `pip install <package>==<version>` or install from a requirements file.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -8,3 +8,4 @@ The following Hadolint-compatible rules are implemented:
 - [DL3002](DL3002.md) - Last USER should not be root.
 - [DL3007](DL3007.md) - Avoid using implicit or `latest` tags.
 - [DL4000](DL4000.md) - `MAINTAINER` is deprecated. Use `LABEL maintainer` instead.
+- [DL3013](DL3013.md) - Pin versions in pip.

--- a/internal/rules/DL3013.go
+++ b/internal/rules/DL3013.go
@@ -1,0 +1,164 @@
+package rules
+
+/*
+ * file: internal/rules/DL3013.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/shlex"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// pinPipVersions enforces version pinning for pip installations.
+type pinPipVersions struct{}
+
+// NewPinPipVersions constructs the rule.
+func NewPinPipVersions() engine.Rule { return pinPipVersions{} }
+
+// ID returns the rule identifier.
+func (pinPipVersions) ID() string { return "DL3013" }
+
+// Check inspects RUN instructions for unpinned pip installs.
+func (pinPipVersions) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") || n.Next == nil {
+			continue
+		}
+		tokens, err := shlex.Split(n.Next.Value)
+		if err != nil {
+			continue
+		}
+		cmds := splitRunCommands(tokens)
+		for _, cmd := range cmds {
+			if violatesPipPin(cmd) {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL3013",
+					Message: "Pin versions in pip. Instead of `pip install <package>` use `pip install <package>==<version>` or `pip install --requirement <requirements file>`",
+					Line:    n.StartLine,
+				})
+				break
+			}
+		}
+	}
+	return findings, nil
+}
+
+// splitRunCommands divides tokens into individual commands based on shell connectors.
+func splitRunCommands(tokens []string) [][]string {
+	connectors := map[string]struct{}{"&&": {}, "||": {}, "|": {}, ";": {}}
+	var result [][]string
+	var current []string
+	for _, tok := range tokens {
+		if _, ok := connectors[tok]; ok {
+			if len(current) > 0 {
+				result = append(result, current)
+				current = nil
+			}
+			continue
+		}
+		current = append(current, tok)
+	}
+	if len(current) > 0 {
+		result = append(result, current)
+	}
+	return result
+}
+
+// violatesPipPin reports whether a pip install command lacks version pinning.
+func violatesPipPin(cmd []string) bool {
+	start, ok := pipInstallIndex(cmd)
+	if !ok {
+		return false
+	}
+	hasConstraint := false
+	requirement := false
+	var pkgs []string
+	flagsWithArg := map[string]struct{}{
+		"abi": {}, "b": {}, "build": {}, "e": {}, "editable": {}, "extra-index-url": {},
+		"f": {}, "find-links": {}, "i": {}, "index-url": {}, "implementation": {},
+		"no-binary": {}, "only-binary": {}, "platform": {}, "prefix": {}, "progress-bar": {},
+		"proxy": {}, "python-version": {}, "root": {}, "src": {}, "t": {}, "target": {},
+		"trusted-host": {}, "upgrade-strategy": {},
+	}
+	for i := start; i < len(cmd); i++ {
+		tok := cmd[i]
+		if strings.HasPrefix(tok, "-") {
+			flag := strings.TrimLeft(tok, "-")
+			switch flag {
+			case "r", "requirement":
+				requirement = true
+				i++
+				break
+			case "c", "constraint":
+				hasConstraint = true
+				i++
+				break
+			default:
+				if _, ok := flagsWithArg[flag]; ok {
+					i++
+				}
+			}
+			continue
+		}
+		if tok == "." {
+			requirement = true
+			break
+		}
+		pkgs = append(pkgs, tok)
+	}
+	if requirement || hasConstraint || len(pkgs) == 0 {
+		return false
+	}
+	for _, p := range pkgs {
+		if !versionFixed(p) {
+			return true
+		}
+	}
+	return false
+}
+
+// pipInstallIndex identifies pip install command and returns index after install token.
+func pipInstallIndex(cmd []string) (int, bool) {
+	if len(cmd) >= 2 && isPip(cmd[0]) && cmd[1] == "install" {
+		return 2, true
+	}
+	if len(cmd) >= 4 && strings.HasPrefix(cmd[0], "python") && cmd[1] == "-m" && isPip(cmd[2]) && cmd[3] == "install" {
+		return 4, true
+	}
+	return 0, false
+}
+
+// isPip reports whether the token refers to pip.
+func isPip(tok string) bool {
+	return strings.HasPrefix(tok, "pip")
+}
+
+// versionFixed reports whether a package token pins its version.
+func versionFixed(pkg string) bool {
+	if strings.Contains(pkg, "@") {
+		return true
+	}
+	symbols := []string{"==", ">=", "<=", ">", "<", "!=", "~=", "==="}
+	for _, s := range symbols {
+		if strings.Contains(pkg, s) {
+			return true
+		}
+	}
+	if strings.HasSuffix(pkg, ".whl") || strings.HasSuffix(pkg, ".tar.gz") {
+		return true
+	}
+	if strings.Contains(pkg, "/") {
+		return true
+	}
+	return false
+}

--- a/internal/rules/DL3013_test.go
+++ b/internal/rules/DL3013_test.go
@@ -1,0 +1,94 @@
+// file: internal/rules/DL3013_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestPinPipVersionsID validates rule identity.
+func TestPinPipVersionsID(t *testing.T) {
+	if NewPinPipVersions().ID() != "DL3013" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestPinPipVersionsViolation detects unpinned pip installs.
+func TestPinPipVersionsViolation(t *testing.T) {
+	src := "FROM alpine\nRUN pip install flask\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewPinPipVersions()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestPinPipVersionsPinned ensures pinned installs pass.
+func TestPinPipVersionsPinned(t *testing.T) {
+	src := "FROM alpine\nRUN pip install flask==1.0\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewPinPipVersions()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestPinPipVersionsRequirement ensures requirement installs are exempt.
+func TestPinPipVersionsRequirement(t *testing.T) {
+	src := "FROM alpine\nRUN pip install --requirement req.txt\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewPinPipVersions()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestPinPipVersionsNilDocument ensures graceful handling of nil input.
+func TestPinPipVersionsNilDocument(t *testing.T) {
+	r := NewPinPipVersions()
+	if findings, err := r.Check(context.Background(), nil); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", findings, err)
+	}
+	if findings, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", findings, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add rule DL3013 to flag unpinned `pip install` commands
- document DL3013 and list it in rules index

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689ea985cff883328e8857c84565b75a