### PR TITLE
feat: add DL3015 rule for apt-get no-install-recommends

### DIFF
--- a/cmd/docker-lint/main.go
+++ b/cmd/docker-lint/main.go
@@ -50,6 +50,7 @@ func run(args []string, out io.Writer) error {
 
 	reg := engine.NewRegistry()
 	reg.Register(rules.NewNoLatestTag())
+	reg.Register(rules.NewAptNoInstallRecommends())
 
 	ctx := context.Background()
 	var all []engine.Finding

--- a/docs/rules/DL3015.md
+++ b/docs/rules/DL3015.md
@@ -1,0 +1,4 @@
+# DL3015 - Use --no-install-recommends with apt-get
+
+The `apt-get install` command installs additional recommended packages by default.
+Use the `--no-install-recommends` flag or set `APT::Install-Recommends=false` to avoid pulling unnecessary dependencies.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -7,4 +7,5 @@ The following Hadolint-compatible rules are implemented:
 - [DL3001](DL3001.md) - Avoid irrelevant shell commands like `ssh` or `vim`.
 - [DL3002](DL3002.md) - Last USER should not be root.
 - [DL3007](DL3007.md) - Avoid using implicit or `latest` tags.
+- [DL3015](DL3015.md) - Require `--no-install-recommends` with apt-get install.
 - [DL4000](DL4000.md) - `MAINTAINER` is deprecated. Use `LABEL maintainer` instead.

--- a/internal/rules/DL3015.go
+++ b/internal/rules/DL3015.go
@@ -1,0 +1,115 @@
+package rules
+
+/*
+ * file: internal/rules/DL3015.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/shlex"
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// aptNoInstallRecommends ensures apt-get install uses --no-install-recommends.
+type aptNoInstallRecommends struct{}
+
+// NewAptNoInstallRecommends constructs the rule.
+func NewAptNoInstallRecommends() engine.Rule { return aptNoInstallRecommends{} }
+
+// ID returns the rule identifier.
+func (aptNoInstallRecommends) ID() string { return "DL3015" }
+
+// Check scans RUN instructions for apt-get install missing --no-install-recommends.
+func (aptNoInstallRecommends) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		tokens := runTokens(n)
+		cmds := splitTokens(tokens)
+		for _, c := range cmds {
+			if aptInstallMissingFlag(c) {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL3015",
+					Message: "Avoid additional packages by specifying `--no-install-recommends`",
+					Line:    n.StartLine,
+				})
+				break
+			}
+		}
+	}
+	return findings, nil
+}
+
+// runTokens returns shell tokens for a RUN instruction.
+func runTokens(n *parser.Node) []string {
+	if n == nil || n.Next == nil {
+		return nil
+	}
+	if n.Attributes != nil && n.Attributes["json"] {
+		var toks []string
+		for c := n.Next; c != nil; c = c.Next {
+			toks = append(toks, c.Value)
+		}
+		return toks
+	}
+	tokens, err := shlex.Split(n.Next.Value)
+	if err != nil {
+		return nil
+	}
+	return tokens
+}
+
+// splitTokens divides tokens into individual commands.
+func splitTokens(tokens []string) [][]string {
+	var cmds [][]string
+	var cur []string
+	for _, t := range tokens {
+		switch t {
+		case "&&", "||", ";", "|":
+			if len(cur) > 0 {
+				cmds = append(cmds, cur)
+				cur = nil
+			}
+		default:
+			cur = append(cur, t)
+		}
+	}
+	if len(cur) > 0 {
+		cmds = append(cmds, cur)
+	}
+	return cmds
+}
+
+// aptInstallMissingFlag reports apt-get install commands lacking no-install-recommends.
+func aptInstallMissingFlag(tokens []string) bool {
+	if len(tokens) == 0 {
+		return false
+	}
+	if strings.ToLower(tokens[0]) != "apt-get" {
+		return false
+	}
+	hasInstall := false
+	hasFlag := false
+	for _, t := range tokens[1:] {
+		lt := strings.ToLower(t)
+		if lt == "install" {
+			hasInstall = true
+			continue
+		}
+		if strings.Contains(lt, "no-install-recommends") || strings.Contains(lt, "apt::install-recommends=false") {
+			hasFlag = true
+		}
+	}
+	return hasInstall && !hasFlag
+}

--- a/internal/rules/DL3015_test.go
+++ b/internal/rules/DL3015_test.go
@@ -1,0 +1,73 @@
+// file: internal/rules/DL3015_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationAptNoInstallRecommendsID validates rule identity.
+func TestIntegrationAptNoInstallRecommendsID(t *testing.T) {
+	if NewAptNoInstallRecommends().ID() != "DL3015" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationAptNoInstallRecommendsViolation detects missing no-install-recommends.
+func TestIntegrationAptNoInstallRecommendsViolation(t *testing.T) {
+	src := "FROM alpine\nRUN apt-get install -y gcc\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewAptNoInstallRecommends()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationAptNoInstallRecommendsClean ensures compliant Dockerfiles pass.
+func TestIntegrationAptNoInstallRecommendsClean(t *testing.T) {
+	src := "FROM alpine\nRUN apt-get install --no-install-recommends -y gcc\nRUN apt-get -o APT::Install-Recommends=false install gcc\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewAptNoInstallRecommends()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationAptNoInstallRecommendsNilDocument ensures graceful handling of nil input.
+func TestIntegrationAptNoInstallRecommendsNilDocument(t *testing.T) {
+	r := NewAptNoInstallRecommends()
+	if findings, err := r.Check(context.Background(), nil); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", findings, err)
+	}
+	if findings, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", findings, err)
+	}
+}


### PR DESCRIPTION
## Summary
- enforce `apt-get install` to include `--no-install-recommends` or `APT::Install-Recommends=false`
- document new rule DL3015 and register in CLI

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689ea9b31dbc8332a2a9bf13279d0a38