### PR TITLE
feat: implement DL3021 trailing slash rule

### DIFF
--- a/docs/rules/DL3021.md
+++ b/docs/rules/DL3021.md
@@ -1,0 +1,3 @@
+# DL3021 - Ensure destination ends with slash when copying multiple sources
+
+COPY instructions that specify more than two arguments must end the destination path with `/` so the engine treats it as a directory.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -11,4 +11,5 @@ The following Hadolint-compatible rules are implemented:
 - [DL3009](DL3009.md) - Delete the APT lists after installing packages.
 - [DL3010](DL3010.md) - Use ADD for extracting archives into an image.
 - [DL3014](DL3014.md) - Use the -y switch for apt-get install.
+- [DL3021](DL3021.md) - COPY with more than 2 arguments requires the last argument to end with /.
 - [DL4000](DL4000.md) - `MAINTAINER` is deprecated. Use `LABEL maintainer` instead.

--- a/internal/rules/DL3021.go
+++ b/internal/rules/DL3021.go
@@ -1,0 +1,49 @@
+package rules
+
+/*
+ * file: internal/rules/DL3021.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// copyDestEndsWithSlash ensures COPY with multiple sources uses a directory destination.
+type copyDestEndsWithSlash struct{}
+
+// NewCopyDestEndsWithSlash constructs the rule.
+func NewCopyDestEndsWithSlash() engine.Rule { return copyDestEndsWithSlash{} }
+
+// ID returns the rule identifier.
+func (copyDestEndsWithSlash) ID() string { return "DL3021" }
+
+// Check verifies that COPY with more than 2 arguments uses a destination ending with '/'.
+func (copyDestEndsWithSlash) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "copy") {
+			continue
+		}
+		tokens := collectArgs(n)
+		if len(tokens) <= 2 {
+			continue
+		}
+		dest := tokens[len(tokens)-1]
+		if !strings.HasSuffix(dest, "/") {
+			findings = append(findings, engine.Finding{
+				RuleID:  "DL3021",
+				Message: "COPY with more than 2 arguments requires the last argument to end with /",
+				Line:    n.StartLine,
+			})
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/DL3021_test.go
+++ b/internal/rules/DL3021_test.go
@@ -1,0 +1,94 @@
+// file: internal/rules/DL3021_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationCopyDestSlashID validates rule identity.
+func TestIntegrationCopyDestSlashID(t *testing.T) {
+	if NewCopyDestEndsWithSlash().ID() != "DL3021" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationCopyDestSlashViolation detects missing trailing slash with multiple sources.
+func TestIntegrationCopyDestSlashViolation(t *testing.T) {
+	src := "FROM alpine\nCOPY file1 file2 /opt\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewCopyDestEndsWithSlash()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationCopyDestSlashClean ensures compliant Dockerfiles pass.
+func TestIntegrationCopyDestSlashClean(t *testing.T) {
+	src := "FROM alpine\nCOPY file1 file2 /opt/\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewCopyDestEndsWithSlash()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationCopyDestSlashSingleSource verifies single-source COPY is ignored.
+func TestIntegrationCopyDestSlashSingleSource(t *testing.T) {
+	src := "FROM alpine\nCOPY file1 /opt\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewCopyDestEndsWithSlash()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationCopyDestSlashNilDocument ensures graceful handling of nil input.
+func TestIntegrationCopyDestSlashNilDocument(t *testing.T) {
+	r := NewCopyDestEndsWithSlash()
+	if findings, err := r.Check(context.Background(), nil); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", findings, err)
+	}
+	if findings, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", findings, err)
+	}
+}


### PR DESCRIPTION
## Summary
- enforce DL3021 to require destination trailing slash when COPY has multiple sources
- add DL3021 documentation and register in rules list
- cover DL3021 with integration tests

## Testing
- `go vet ./...`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_689eab88a5b4833296f8c67ba7b24cad