### PR TITLE
feat: add DL3019 apk no-cache rule

### DIFF
--- a/docs/rules/DL3019.md
+++ b/docs/rules/DL3019.md
@@ -1,0 +1,3 @@
+# DL3019 - Use --no-cache with apk add
+
+Use the `--no-cache` switch to avoid the need to use `--update` and remove `/var/cache/apk/*` when installing packages with `apk add`.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -11,4 +11,5 @@ The following Hadolint-compatible rules are implemented:
 - [DL3009](DL3009.md) - Delete the APT lists after installing packages.
 - [DL3010](DL3010.md) - Use ADD for extracting archives into an image.
 - [DL3014](DL3014.md) - Use the -y switch for apt-get install.
+- [DL3019](DL3019.md) - Use --no-cache with apk add.
 - [DL4000](DL4000.md) - `MAINTAINER` is deprecated. Use `LABEL maintainer` instead.

--- a/internal/rules/DL3019.go
+++ b/internal/rules/DL3019.go
@@ -1,0 +1,117 @@
+package rules
+
+/*
+ * file: internal/rules/DL3019.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/shlex"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// apkNoCache enforces use of --no-cache for apk add unless cache mount is present.
+type apkNoCache struct{}
+
+// NewApkNoCache constructs the rule.
+func NewApkNoCache() engine.Rule { return apkNoCache{} }
+
+// ID returns the rule identifier.
+func (apkNoCache) ID() string { return "DL3019" }
+
+// Check examines RUN instructions for apk add missing --no-cache and without cache mount.
+func (apkNoCache) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		if hasApkCacheMount(n.Flags) {
+			continue
+		}
+		if n.Next == nil {
+			continue
+		}
+		tokens, err := shlex.Split(n.Next.Value)
+		if err != nil {
+			continue
+		}
+		segments := splitByConnectors(tokens)
+		for _, seg := range segments {
+			if isApkAdd(seg) && !hasNoCache(seg) {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL3019",
+					Message: "Use the `--no-cache` switch to avoid the need to use `--update` and remove `/var/cache/apk/*` when done installing packages",
+					Line:    n.StartLine,
+				})
+				break
+			}
+		}
+	}
+	return findings, nil
+}
+
+// hasApkCacheMount reports whether a cache mount targets /var/cache/apk.
+func hasApkCacheMount(flags []string) bool {
+	for _, f := range flags {
+		lf := strings.ToLower(f)
+		if !strings.HasPrefix(lf, "--mount=") {
+			continue
+		}
+		opts := strings.Split(strings.TrimPrefix(lf, "--mount="), ",")
+		typeCache := false
+		targetMatch := false
+		for _, o := range opts {
+			if strings.HasPrefix(o, "type=") && strings.TrimPrefix(o, "type=") == "cache" {
+				typeCache = true
+			}
+			if strings.HasPrefix(o, "target=") || strings.HasPrefix(o, "dst=") || strings.HasPrefix(o, "destination=") {
+				p := strings.TrimPrefix(o, "target=")
+				p = strings.TrimPrefix(p, "dst=")
+				p = strings.TrimPrefix(p, "destination=")
+				p = strings.TrimRight(p, "/")
+				if p == "/var/cache/apk" {
+					targetMatch = true
+				}
+			}
+		}
+		if typeCache && targetMatch {
+			return true
+		}
+	}
+	return false
+}
+
+// isApkAdd reports whether tokens start with `apk` and include `add`.
+func isApkAdd(tokens []string) bool {
+	if len(tokens) < 2 {
+		return false
+	}
+	if strings.ToLower(tokens[0]) != "apk" {
+		return false
+	}
+	for _, t := range tokens[1:] {
+		if strings.ToLower(t) == "add" {
+			return true
+		}
+	}
+	return false
+}
+
+// hasNoCache checks for --no-cache flag.
+func hasNoCache(tokens []string) bool {
+	for _, t := range tokens[1:] {
+		if strings.ToLower(t) == "--no-cache" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rules/DL3019_test.go
+++ b/internal/rules/DL3019_test.go
@@ -1,0 +1,94 @@
+// file: internal/rules/DL3019_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationApkNoCacheID validates rule identity.
+func TestIntegrationApkNoCacheID(t *testing.T) {
+	if NewApkNoCache().ID() != "DL3019" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationApkNoCacheViolation flags missing --no-cache on apk add.
+func TestIntegrationApkNoCacheViolation(t *testing.T) {
+	src := "FROM alpine\nRUN apk add curl\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewApkNoCache()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationApkNoCacheClean ensures --no-cache suppresses findings.
+func TestIntegrationApkNoCacheClean(t *testing.T) {
+	src := "FROM alpine\nRUN apk add --no-cache curl\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewApkNoCache()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationApkNoCacheMount accepts BuildKit cache mount for apk cache.
+func TestIntegrationApkNoCacheMount(t *testing.T) {
+	src := "FROM alpine\nRUN --mount=type=cache,target=/var/cache/apk apk add curl\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewApkNoCache()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationApkNoCacheNilDocument ensures graceful handling of nil input.
+func TestIntegrationApkNoCacheNilDocument(t *testing.T) {
+	r := NewApkNoCache()
+	if findings, err := r.Check(context.Background(), nil); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", findings, err)
+	}
+	if findings, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", findings, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add DL3019 rule to require --no-cache for apk add or a cache mount
- document DL3019 and list it in rule README
- test apk cache behavior

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689eab6191e0833296b66e73aae1a503