### PR TITLE
feat: add DL3018 rule for apk version pinning

### DIFF
--- a/docs/rules/DL3018.md
+++ b/docs/rules/DL3018.md
@@ -1,0 +1,4 @@
+# DL3018 - Pin versions in apk add
+
+Ensure packages installed via `apk add` are pinned to a version using `=<version>` or installed from `.apk` files to improve build reproducibility.
+

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -11,4 +11,5 @@ The following Hadolint-compatible rules are implemented:
 - [DL3009](DL3009.md) - Delete the APT lists after installing packages.
 - [DL3010](DL3010.md) - Use ADD for extracting archives into an image.
 - [DL3014](DL3014.md) - Use the -y switch for apt-get install.
+- [DL3018](DL3018.md) - Pin versions in apk add.
 - [DL4000](DL4000.md) - `MAINTAINER` is deprecated. Use `LABEL maintainer` instead.

--- a/internal/rules/DL3018.go
+++ b/internal/rules/DL3018.go
@@ -1,0 +1,93 @@
+package rules
+
+/*
+ * file: internal/rules/DL3018.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// apkPin ensures packages installed with apk add are version pinned.
+type apkPin struct{}
+
+// NewApkPin constructs the rule.
+func NewApkPin() engine.Rule { return apkPin{} }
+
+// ID returns the rule identifier.
+func (apkPin) ID() string { return "DL3018" }
+
+// Check evaluates RUN instructions for unpinned apk adds.
+func (apkPin) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") || n.Next == nil {
+			continue
+		}
+		cmd := n.Next.Value
+		if hasUnpinnedApkAdd(cmd) {
+			findings = append(findings, engine.Finding{
+				RuleID:  "DL3018",
+				Message: "Pin versions in apk add. Instead of 'apk add <package>' use 'apk add <package>=<version>'.",
+				Line:    n.StartLine,
+			})
+		}
+	}
+	return findings, nil
+}
+
+var apkSplitter = regexp.MustCompile(`\s*(?:&&|\|\||;)\s*`)
+
+func hasUnpinnedApkAdd(cmd string) bool {
+	cmd = strings.ReplaceAll(cmd, "\\\n", " ")
+	cmd = strings.ReplaceAll(cmd, "\n", " ")
+	parts := apkSplitter.Split(cmd, -1)
+	for _, part := range parts {
+		tokens := strings.Fields(part)
+		for i := 0; i < len(tokens); i++ {
+			if tokens[i] == "apk" {
+				for j := i + 1; j < len(tokens); j++ {
+					t := tokens[j]
+					if t == "add" {
+						if unpinnedApkPackages(tokens[j+1:]) {
+							return true
+						}
+						break
+					}
+					if !strings.HasPrefix(t, "-") {
+						break
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+func unpinnedApkPackages(args []string) bool {
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") {
+			continue
+		}
+		if strings.HasSuffix(a, ".apk") {
+			continue
+		}
+		if !strings.Contains(a, "=") {
+			return true
+		}
+		parts := strings.SplitN(a, "=", 2)
+		if parts[1] == "" || strings.HasPrefix(parts[1], "-") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rules/DL3018_test.go
+++ b/internal/rules/DL3018_test.go
@@ -1,0 +1,94 @@
+// file: internal/rules/DL3018_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationApkPinID validates rule identity.
+func TestIntegrationApkPinID(t *testing.T) {
+	if NewApkPin().ID() != "DL3018" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationApkPinViolation detects unpinned apk adds.
+func TestIntegrationApkPinViolation(t *testing.T) {
+	r := NewApkPin()
+	src := "FROM alpine\nRUN apk add curl\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationApkPinClean ensures compliant apk adds pass.
+func TestIntegrationApkPinClean(t *testing.T) {
+	r := NewApkPin()
+	src := "FROM alpine\nRUN apk add curl=8.0.1 bash=5.1.0\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationApkPinApkFile ensures .apk packages are treated as pinned.
+func TestIntegrationApkPinApkFile(t *testing.T) {
+	r := NewApkPin()
+	src := "FROM alpine\nRUN apk add /tmp/pkg.apk\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationApkPinNilDocument ensures graceful handling of nil input.
+func TestIntegrationApkPinNilDocument(t *testing.T) {
+	r := NewApkPin()
+	if findings, err := r.Check(context.Background(), nil); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", findings, err)
+	}
+	if findings, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", findings, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add DL3018 rule to ensure `apk add` packages are version pinned
- document rule DL3018 and list it in the rules index

## Testing
- `go vet ./... && echo vet-done`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689eab4fe59c8332a51650d8e589d678