### PR TITLE
Add DL3020 rule to prefer COPY over ADD

### DIFF
--- a/docs/rules/DL3020.md
+++ b/docs/rules/DL3020.md
@@ -1,0 +1,3 @@
+# DL3020 - Use COPY instead of ADD for files and folders
+
+Use `COPY` for copying local files or directories. `ADD` should be reserved for remote URLs or archives that need automatic extraction.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -11,4 +11,5 @@ The following Hadolint-compatible rules are implemented:
 - [DL3009](DL3009.md) - Delete the APT lists after installing packages.
 - [DL3010](DL3010.md) - Use ADD for extracting archives into an image.
 - [DL3014](DL3014.md) - Use the -y switch for apt-get install.
+- [DL3020](DL3020.md) - Use COPY instead of ADD for files and folders.
 - [DL4000](DL4000.md) - `MAINTAINER` is deprecated. Use `LABEL maintainer` instead.

--- a/internal/rules/DL3020.go
+++ b/internal/rules/DL3020.go
@@ -1,0 +1,87 @@
+package rules
+
+/*
+ * file: internal/rules/DL3020.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// useCopyInsteadOfAdd advises using COPY for local files and folders.
+type useCopyInsteadOfAdd struct{}
+
+// NewUseCopyInsteadOfAdd constructs the rule.
+func NewUseCopyInsteadOfAdd() engine.Rule { return useCopyInsteadOfAdd{} }
+
+// ID returns the rule identifier.
+func (useCopyInsteadOfAdd) ID() string { return "DL3020" }
+
+// Check inspects ADD instructions for local sources that are neither URLs nor archives.
+func (useCopyInsteadOfAdd) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "add") {
+			continue
+		}
+		tokens := collectArgs(n)
+		if len(tokens) < 2 {
+			continue
+		}
+		sources := tokens[:len(tokens)-1]
+		for _, src := range sources {
+			if !isURL(src) && !isArchive(src) {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL3020",
+					Message: "Use COPY instead of ADD for files and folders",
+					Line:    n.StartLine,
+				})
+				break
+			}
+		}
+	}
+	return findings, nil
+}
+
+// isURL reports whether the path appears to be a remote URL.
+func isURL(p string) bool {
+	lp := strings.ToLower(p)
+	return strings.HasPrefix(lp, "http://") || strings.HasPrefix(lp, "https://")
+}
+
+var archiveFileExtensions = []string{
+	".tar",
+	".z",
+	".bz2",
+	".gz",
+	".lz",
+	".lzma",
+	".tz",
+	".tb2",
+	".tbz",
+	".tbz2",
+	".tgz",
+	".tlz",
+	".tpz",
+	".txz",
+	".xz",
+}
+
+// isArchive reports whether the path looks like a compressed archive.
+func isArchive(p string) bool {
+	lp := strings.ToLower(p)
+	for _, ext := range archiveFileExtensions {
+		if strings.HasSuffix(lp, ext) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rules/DL3020_test.go
+++ b/internal/rules/DL3020_test.go
@@ -1,0 +1,136 @@
+// file: internal/rules/DL3020_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationUseCopyInsteadOfAddID validates rule identity.
+func TestIntegrationUseCopyInsteadOfAddID(t *testing.T) {
+	if NewUseCopyInsteadOfAdd().ID() != "DL3020" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationUseCopyInsteadOfAddViolation reports using ADD for local files.
+func TestIntegrationUseCopyInsteadOfAddViolation(t *testing.T) {
+	src := "FROM alpine\nADD file /dest\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewUseCopyInsteadOfAdd()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 || findings[0].Line != 2 {
+		t.Fatalf("expected one finding on line 2, got %#v", findings)
+	}
+}
+
+// TestIntegrationUseCopyInsteadOfAddRemote allows remote URLs.
+func TestIntegrationUseCopyInsteadOfAddRemote(t *testing.T) {
+	src := "FROM alpine\nADD https://example.com/file.tgz /dest\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewUseCopyInsteadOfAdd()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationUseCopyInsteadOfAddArchive allows archive extraction.
+func TestIntegrationUseCopyInsteadOfAddArchive(t *testing.T) {
+	src := "FROM alpine\nADD file.tar.gz /dest\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewUseCopyInsteadOfAdd()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationUseCopyInsteadOfAddJSON handles JSON-array form.
+func TestIntegrationUseCopyInsteadOfAddJSON(t *testing.T) {
+	src := "FROM alpine\nADD [\"file\",\"/dest\"]\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewUseCopyInsteadOfAdd()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationUseCopyInsteadOfAddMultiple ensures any local source triggers.
+func TestIntegrationUseCopyInsteadOfAddMultiple(t *testing.T) {
+	src := "FROM alpine\nADD file file.tar.gz /dest\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewUseCopyInsteadOfAdd()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationUseCopyInsteadOfAddNilDocument ensures nil input is handled.
+func TestIntegrationUseCopyInsteadOfAddNilDocument(t *testing.T) {
+	r := NewUseCopyInsteadOfAdd()
+	if findings, err := r.Check(context.Background(), nil); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", findings, err)
+	}
+	if findings, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", findings, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add rule DL3020 to flag ADD of local files or directories
- document rule DL3020

## Testing
- `go vet ./...`
- `go test ./... -short`


------
https://chatgpt.com/codex/tasks/task_b_689eab756a408332bf26b925ab63f2da