### PR TITLE
Implement hadolint rules DL3022–DL3028

### DIFF
--- a/docs/rules/DL3022.md
+++ b/docs/rules/DL3022.md
@@ -1,0 +1,4 @@
+# DL3022 - COPY --from should reference a previous FROM alias
+
+When using multi-stage builds, `COPY --from` must reference an alias or index
+that refers to a stage defined earlier in the Dockerfile.

--- a/docs/rules/DL3023.md
+++ b/docs/rules/DL3023.md
@@ -1,0 +1,4 @@
+# DL3023 - COPY --from cannot reference its own stage
+
+A `COPY --from` flag may not reference the current build stage. Use earlier
+stages or external images instead.

--- a/docs/rules/DL3024.md
+++ b/docs/rules/DL3024.md
@@ -1,0 +1,4 @@
+# DL3024 - FROM aliases must be unique
+
+Each stage defined with `FROM ... AS <name>` must use a unique alias name to
+avoid ambiguity in multi-stage builds.

--- a/docs/rules/DL3025.md
+++ b/docs/rules/DL3025.md
@@ -1,0 +1,4 @@
+# DL3025 - Use JSON notation for CMD and ENTRYPOINT
+
+Specify `CMD` and `ENTRYPOINT` arguments using JSON array form to avoid shell
+interpretation issues.

--- a/docs/rules/DL3026.md
+++ b/docs/rules/DL3026.md
@@ -1,0 +1,4 @@
+# DL3026 - Restrict registries used in FROM images
+
+Base images should originate from registries explicitly allowed by policy.
+Any `FROM` instruction using an unapproved registry triggers this rule.

--- a/docs/rules/DL3027.md
+++ b/docs/rules/DL3027.md
@@ -1,0 +1,4 @@
+# DL3027 - Avoid using apt
+
+The `apt` tool is intended for interactive use. Use `apt-get` or `apt-cache`
+instead in Dockerfile `RUN` instructions.

--- a/docs/rules/DL3028.md
+++ b/docs/rules/DL3028.md
@@ -1,0 +1,4 @@
+# DL3028 - Pin gem versions
+
+When installing gems, specify versions explicitly. Use `gem install <gem>:<version>`
+instead of unpinned installs.

--- a/internal/rules/DL3022.go
+++ b/internal/rules/DL3022.go
@@ -1,0 +1,64 @@
+// file: internal/rules/DL3022.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// copyFromPreviousStage verifies COPY --from references a prior stage.
+type copyFromPreviousStage struct{}
+
+// NewCopyFromPreviousStage constructs the rule.
+func NewCopyFromPreviousStage() engine.Rule { return copyFromPreviousStage{} }
+
+// ID returns the rule identifier.
+func (copyFromPreviousStage) ID() string { return "DL3022" }
+
+// Check ensures COPY --from references a previously defined stage alias or index.
+func (copyFromPreviousStage) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	aliases := map[string]struct{}{}
+	stageCount := 0
+	for _, n := range d.AST.Children {
+		if strings.EqualFold(n.Value, "from") {
+			stageCount++
+			if name := stageAlias(n); name != "" {
+				aliases[strings.ToLower(name)] = struct{}{}
+			}
+			continue
+		}
+		if !strings.EqualFold(n.Value, "copy") {
+			continue
+		}
+		from, ok := copyFromFlag(n)
+		if !ok {
+			continue
+		}
+		if strings.Contains(from, ":") {
+			continue
+		}
+		if _, ok := aliases[strings.ToLower(from)]; ok {
+			continue
+		}
+		if idx, err := strconv.Atoi(from); err == nil {
+			if idx < stageCount-1 {
+				continue
+			}
+		}
+		findings = append(findings, engine.Finding{
+			RuleID:  "DL3022",
+			Message: "`COPY --from` should reference a previously defined `FROM` alias",
+			Line:    n.StartLine,
+		})
+	}
+	return findings, nil
+}

--- a/internal/rules/DL3022_test.go
+++ b/internal/rules/DL3022_test.go
@@ -1,0 +1,115 @@
+// file: internal/rules/DL3022_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationCopyFromPreviousStageID validates rule identity.
+func TestIntegrationCopyFromPreviousStageID(t *testing.T) {
+	if NewCopyFromPreviousStage().ID() != "DL3022" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationCopyFromPreviousStageViolation detects missing aliases.
+func TestIntegrationCopyFromPreviousStageViolation(t *testing.T) {
+	src := "FROM alpine\nCOPY --from=bogus /src /dest\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewCopyFromPreviousStage()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationCopyFromPreviousStageNumeric validates numeric stage references.
+func TestIntegrationCopyFromPreviousStageNumeric(t *testing.T) {
+	src := "FROM alpine\nCOPY --from=1 /src /dest\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewCopyFromPreviousStage()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationCopyFromPreviousStageClean ensures compliant Dockerfiles pass.
+func TestIntegrationCopyFromPreviousStageClean(t *testing.T) {
+	src := "FROM alpine AS build\nFROM alpine\nCOPY --from=build /src /dest\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewCopyFromPreviousStage()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationCopyFromPreviousStageExternalImage ignores external references.
+func TestIntegrationCopyFromPreviousStageExternalImage(t *testing.T) {
+	src := "FROM alpine\nCOPY --from=alpine:latest /src /dest\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewCopyFromPreviousStage()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationCopyFromPreviousStageNil ensures graceful handling of nil input.
+func TestIntegrationCopyFromPreviousStageNil(t *testing.T) {
+	r := NewCopyFromPreviousStage()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/DL3023.go
+++ b/internal/rules/DL3023.go
@@ -1,0 +1,65 @@
+// file: internal/rules/DL3023.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// copyFromSelf disallows COPY --from referencing current stage.
+type copyFromSelf struct{}
+
+// NewCopyFromSelf constructs the rule.
+func NewCopyFromSelf() engine.Rule { return copyFromSelf{} }
+
+// ID returns the rule identifier.
+func (copyFromSelf) ID() string { return "DL3023" }
+
+// Check flags COPY --from that references its own FROM alias or index.
+func (copyFromSelf) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	currentAlias := ""
+	currentIndex := -1
+	index := -1
+	for _, n := range d.AST.Children {
+		if strings.EqualFold(n.Value, "from") {
+			index++
+			currentIndex = index
+			currentAlias = strings.ToLower(stageAlias(n))
+			continue
+		}
+		if !strings.EqualFold(n.Value, "copy") {
+			continue
+		}
+		from, ok := copyFromFlag(n)
+		if !ok {
+			continue
+		}
+		if strings.EqualFold(strings.ToLower(from), currentAlias) {
+			findings = append(findings, engine.Finding{
+				RuleID:  "DL3023",
+				Message: "`COPY --from` cannot reference its own `FROM` alias",
+				Line:    n.StartLine,
+			})
+			continue
+		}
+		if idx, err := strconv.Atoi(from); err == nil {
+			if idx == currentIndex {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL3023",
+					Message: "`COPY --from` cannot reference its own `FROM` alias",
+					Line:    n.StartLine,
+				})
+			}
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/DL3023_test.go
+++ b/internal/rules/DL3023_test.go
@@ -1,0 +1,94 @@
+// file: internal/rules/DL3023_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationCopyFromSelfID validates rule identity.
+func TestIntegrationCopyFromSelfID(t *testing.T) {
+	if NewCopyFromSelf().ID() != "DL3023" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationCopyFromSelfAlias detects self-references by alias.
+func TestIntegrationCopyFromSelfAlias(t *testing.T) {
+	src := "FROM alpine AS build\nCOPY --from=build /src /dest\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewCopyFromSelf()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationCopyFromSelfIndex detects self-references by index.
+func TestIntegrationCopyFromSelfIndex(t *testing.T) {
+	src := "FROM alpine\nCOPY --from=0 /src /dest\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewCopyFromSelf()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationCopyFromSelfClean ensures compliant Dockerfiles pass.
+func TestIntegrationCopyFromSelfClean(t *testing.T) {
+	src := "FROM alpine AS build\nFROM alpine\nCOPY --from=build /src /dest\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewCopyFromSelf()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationCopyFromSelfNil ensures graceful handling of nil input.
+func TestIntegrationCopyFromSelfNil(t *testing.T) {
+	r := NewCopyFromSelf()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/DL3024.go
+++ b/internal/rules/DL3024.go
@@ -1,0 +1,47 @@
+// file: internal/rules/DL3024.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// uniqueStageNames ensures FROM aliases are unique.
+type uniqueStageNames struct{}
+
+// NewUniqueStageNames constructs the rule.
+func NewUniqueStageNames() engine.Rule { return uniqueStageNames{} }
+
+// ID returns the rule identifier.
+func (uniqueStageNames) ID() string { return "DL3024" }
+
+// Check verifies no duplicate stage aliases exist.
+func (uniqueStageNames) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	aliases := map[string]int{}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "from") {
+			continue
+		}
+		if name := strings.ToLower(stageAlias(n)); name != "" {
+			if line, ok := aliases[name]; ok {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL3024",
+					Message: "FROM aliases (stage names) must be unique",
+					Line:    n.StartLine,
+				})
+				_ = line // previously stored; not used further
+			} else {
+				aliases[name] = n.StartLine
+			}
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/DL3024_test.go
+++ b/internal/rules/DL3024_test.go
@@ -1,0 +1,73 @@
+// file: internal/rules/DL3024_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationUniqueStageNamesID validates rule identity.
+func TestIntegrationUniqueStageNamesID(t *testing.T) {
+	if NewUniqueStageNames().ID() != "DL3024" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationUniqueStageNamesViolation detects duplicate aliases.
+func TestIntegrationUniqueStageNamesViolation(t *testing.T) {
+	src := "FROM alpine AS base\nFROM ubuntu AS base\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewUniqueStageNames()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationUniqueStageNamesClean ensures compliant Dockerfiles pass.
+func TestIntegrationUniqueStageNamesClean(t *testing.T) {
+	src := "FROM alpine AS base\nFROM ubuntu AS build\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewUniqueStageNames()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationUniqueStageNamesNil ensures graceful handling of nil input.
+func TestIntegrationUniqueStageNamesNil(t *testing.T) {
+	r := NewUniqueStageNames()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/DL3025.go
+++ b/internal/rules/DL3025.go
@@ -1,0 +1,41 @@
+// file: internal/rules/DL3025.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// jsonNotationCmdEntrypoint enforces JSON array form for CMD and ENTRYPOINT.
+type jsonNotationCmdEntrypoint struct{}
+
+// NewJSONNotationCmdEntrypoint constructs the rule.
+func NewJSONNotationCmdEntrypoint() engine.Rule { return jsonNotationCmdEntrypoint{} }
+
+// ID returns the rule identifier.
+func (jsonNotationCmdEntrypoint) ID() string { return "DL3025" }
+
+// Check reports CMD or ENTRYPOINT using shell form.
+func (jsonNotationCmdEntrypoint) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "cmd") && !strings.EqualFold(n.Value, "entrypoint") {
+			continue
+		}
+		if n.Attributes == nil || !n.Attributes["json"] {
+			findings = append(findings, engine.Finding{
+				RuleID:  "DL3025",
+				Message: "Use arguments JSON notation for CMD and ENTRYPOINT arguments",
+				Line:    n.StartLine,
+			})
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/DL3025_test.go
+++ b/internal/rules/DL3025_test.go
@@ -1,0 +1,73 @@
+// file: internal/rules/DL3025_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationJSONNotationCmdEntrypointID validates rule identity.
+func TestIntegrationJSONNotationCmdEntrypointID(t *testing.T) {
+	if NewJSONNotationCmdEntrypoint().ID() != "DL3025" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationJSONNotationCmdEntrypointViolation detects shell form usage.
+func TestIntegrationJSONNotationCmdEntrypointViolation(t *testing.T) {
+	src := "FROM alpine\nCMD echo hi\nENTRYPOINT echo hi\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewJSONNotationCmdEntrypoint()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("expected two findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationJSONNotationCmdEntrypointClean ensures compliant Dockerfiles pass.
+func TestIntegrationJSONNotationCmdEntrypointClean(t *testing.T) {
+	src := "FROM alpine\nCMD [\"echo\",\"hi\"]\nENTRYPOINT [\"echo\",\"hi\"]\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewJSONNotationCmdEntrypoint()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationJSONNotationCmdEntrypointNil ensures graceful handling of nil input.
+func TestIntegrationJSONNotationCmdEntrypointNil(t *testing.T) {
+	r := NewJSONNotationCmdEntrypoint()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/DL3026.go
+++ b/internal/rules/DL3026.go
@@ -1,0 +1,103 @@
+// file: internal/rules/DL3026.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// allowedRegistry enforces FROM images use only allowed registries.
+type allowedRegistry struct {
+	allowed []string
+}
+
+// NewAllowedRegistry constructs the rule.
+func NewAllowedRegistry(allowed []string) engine.Rule { return &allowedRegistry{allowed: allowed} }
+
+// ID returns the rule identifier.
+func (allowedRegistry) ID() string { return "DL3026" }
+
+// Check validates registry usage in FROM instructions.
+func (r *allowedRegistry) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	aliases := map[string]struct{}{}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "from") {
+			continue
+		}
+		image := ""
+		if n.Next != nil {
+			image = n.Next.Value
+		}
+		alias := strings.ToLower(stageAlias(n))
+		if alias != "" {
+			aliases[alias] = struct{}{}
+		}
+		if _, ok := aliases[strings.ToLower(image)]; ok {
+			continue // referencing previous stage
+		}
+		if len(r.allowed) == 0 {
+			continue
+		}
+		if !r.isAllowed(image) {
+			findings = append(findings, engine.Finding{
+				RuleID:  "DL3026",
+				Message: "Use only an allowed registry in the FROM image",
+				Line:    n.StartLine,
+			})
+		}
+	}
+	return findings, nil
+}
+
+// isAllowed reports if the image registry is permitted.
+func (r *allowedRegistry) isAllowed(image string) bool {
+	registry := parseRegistry(image)
+	if registry == "" {
+		if strings.EqualFold(image, "scratch") {
+			return true
+		}
+		return r.match("docker.io") || r.match("hub.docker.com")
+	}
+	return r.match(registry)
+}
+
+// match checks allowed patterns against registry.
+func (r *allowedRegistry) match(registry string) bool {
+	for _, a := range r.allowed {
+		if matchRegistryPattern(a, registry) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseRegistry extracts the registry part of an image reference.
+func parseRegistry(image string) string {
+	parts := strings.Split(image, "/")
+	if len(parts) > 1 && (strings.Contains(parts[0], ".") || strings.Contains(parts[0], ":") || parts[0] == "localhost") {
+		return parts[0]
+	}
+	return ""
+}
+
+// matchRegistryPattern matches registry against pattern with '*' prefix or suffix.
+func matchRegistryPattern(pattern, registry string) bool {
+	if pattern == "*" {
+		return true
+	}
+	if strings.HasPrefix(pattern, "*") {
+		return strings.HasSuffix(registry, pattern[1:])
+	}
+	if strings.HasSuffix(pattern, "*") {
+		return strings.HasPrefix(registry, pattern[:len(pattern)-1])
+	}
+	return registry == pattern
+}

--- a/internal/rules/DL3026_test.go
+++ b/internal/rules/DL3026_test.go
@@ -1,0 +1,94 @@
+// file: internal/rules/DL3026_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationAllowedRegistryID validates rule identity.
+func TestIntegrationAllowedRegistryID(t *testing.T) {
+	if NewAllowedRegistry(nil).ID() != "DL3026" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationAllowedRegistryViolation detects disallowed registry usage.
+func TestIntegrationAllowedRegistryViolation(t *testing.T) {
+	src := "FROM alpine\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewAllowedRegistry([]string{"my.registry"})
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationAllowedRegistryClean ensures allowed registries pass.
+func TestIntegrationAllowedRegistryClean(t *testing.T) {
+	src := "FROM my.registry/alpine\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewAllowedRegistry([]string{"my.registry"})
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationAllowedRegistryAlias ensures stage aliases bypass registry check.
+func TestIntegrationAllowedRegistryAlias(t *testing.T) {
+	src := "FROM my.registry/alpine AS build\nFROM build\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewAllowedRegistry([]string{"my.registry"})
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationAllowedRegistryNil ensures graceful handling of nil input.
+func TestIntegrationAllowedRegistryNil(t *testing.T) {
+	r := NewAllowedRegistry([]string{"my.registry"})
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/DL3027.go
+++ b/internal/rules/DL3027.go
@@ -1,0 +1,45 @@
+// file: internal/rules/DL3027.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// noAptCommand warns against using apt instead of apt-get or apt-cache.
+type noAptCommand struct{}
+
+// NewNoAptCommand constructs the rule.
+func NewNoAptCommand() engine.Rule { return noAptCommand{} }
+
+// ID returns the rule identifier.
+func (noAptCommand) ID() string { return "DL3027" }
+
+// Check scans RUN instructions for apt usage.
+func (noAptCommand) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		cmds := extractCommands(n)
+		for _, c := range cmds {
+			if c == "apt" {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL3027",
+					Message: "Do not use apt as it is meant to be an end-user tool, use apt-get or apt-cache instead",
+					Line:    n.StartLine,
+				})
+				break
+			}
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/DL3027_test.go
+++ b/internal/rules/DL3027_test.go
@@ -1,0 +1,73 @@
+// file: internal/rules/DL3027_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationNoAptCommandID validates rule identity.
+func TestIntegrationNoAptCommandID(t *testing.T) {
+	if NewNoAptCommand().ID() != "DL3027" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationNoAptCommandViolation detects apt usage.
+func TestIntegrationNoAptCommandViolation(t *testing.T) {
+	src := "FROM alpine\nRUN apt update\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewNoAptCommand()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationNoAptCommandClean ensures compliant Dockerfiles pass.
+func TestIntegrationNoAptCommandClean(t *testing.T) {
+	src := "FROM alpine\nRUN apt-get update\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewNoAptCommand()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationNoAptCommandNil ensures graceful handling of nil input.
+func TestIntegrationNoAptCommandNil(t *testing.T) {
+	r := NewNoAptCommand()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/DL3028.go
+++ b/internal/rules/DL3028.go
@@ -1,0 +1,75 @@
+// file: internal/rules/DL3028.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// pinGemVersions enforces version pinning in gem install commands.
+type pinGemVersions struct{}
+
+// NewPinGemVersions constructs the rule.
+func NewPinGemVersions() engine.Rule { return pinGemVersions{} }
+
+// ID returns the rule identifier.
+func (pinGemVersions) ID() string { return "DL3028" }
+
+// Check inspects RUN instructions for unpinned gem installs.
+func (pinGemVersions) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		segments := splitRunSegments(n)
+		for _, seg := range segments {
+			if violatesGemPin(seg) {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL3028",
+					Message: "Pin versions in gem install. Instead of `gem install <gem>` use `gem install <gem>:<version>`",
+					Line:    n.StartLine,
+				})
+				break
+			}
+		}
+	}
+	return findings, nil
+}
+
+// violatesGemPin reports whether a command segment uses gem install without version.
+func violatesGemPin(seg []string) bool {
+	for i := 0; i < len(seg); i++ {
+		if seg[i] != "gem" {
+			continue
+		}
+		if i+1 >= len(seg) || (seg[i+1] != "install" && seg[i+1] != "i") {
+			continue
+		}
+		args := seg[i+2:]
+		for _, a := range args {
+			if a == "-v" || a == "--version" || strings.HasPrefix(a, "--version=") {
+				return false
+			}
+		}
+		for _, a := range args {
+			if a == "--" {
+				break
+			}
+			if strings.HasPrefix(a, "-") {
+				continue
+			}
+			if a != "install" && a != "i" && !strings.Contains(a, ":") {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/rules/DL3028_test.go
+++ b/internal/rules/DL3028_test.go
@@ -1,0 +1,94 @@
+// file: internal/rules/DL3028_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationPinGemVersionsID validates rule identity.
+func TestIntegrationPinGemVersionsID(t *testing.T) {
+	if NewPinGemVersions().ID() != "DL3028" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationPinGemVersionsViolation detects unpinned gem installs.
+func TestIntegrationPinGemVersionsViolation(t *testing.T) {
+	src := "FROM alpine\nRUN gem install rake\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewPinGemVersions()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationPinGemVersionsClean ensures compliant Dockerfiles pass.
+func TestIntegrationPinGemVersionsClean(t *testing.T) {
+	src := "FROM alpine\nRUN gem install rake:1.0\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewPinGemVersions()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationPinGemVersionsOptionSkipped ensures version options skip rule.
+func TestIntegrationPinGemVersionsOptionSkipped(t *testing.T) {
+	src := "FROM alpine\nRUN gem install rake -v 1.2.3\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewPinGemVersions()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationPinGemVersionsNil ensures graceful handling of nil input.
+func TestIntegrationPinGemVersionsNil(t *testing.T) {
+	r := NewPinGemVersions()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/stage_utils.go
+++ b/internal/rules/stage_utils.go
@@ -1,0 +1,34 @@
+// file: internal/rules/stage_utils.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+)
+
+// copyFromFlag extracts the value of --from from a COPY node.
+func copyFromFlag(n *parser.Node) (string, bool) {
+	for _, f := range n.Flags {
+		if strings.HasPrefix(strings.ToLower(f), "--from=") {
+			v := strings.TrimPrefix(f, "--from=")
+			v = strings.Trim(v, "\"'")
+			return v, true
+		}
+	}
+	return "", false
+}
+
+// stageAlias returns the alias specified in a FROM instruction.
+func stageAlias(n *parser.Node) string {
+	if n == nil || n.Next == nil {
+		return ""
+	}
+	for tok := n.Next.Next; tok != nil; tok = tok.Next {
+		if strings.EqualFold(tok.Value, "as") && tok.Next != nil {
+			return tok.Next.Value
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary
- add validation for `COPY --from` to ensure it targets prior stages and not the current one
- require unique stage aliases and JSON form for `CMD`/`ENTRYPOINT`
- restrict `FROM` registries, flag `apt` usage, and enforce gem version pinning

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689eabc2d20883328c278b1504f7c9d3