### PR TITLE
test: expand coverage for rules

### DIFF
--- a/internal/rules/DL1001_test.go
+++ b/internal/rules/DL1001_test.go
@@ -60,3 +60,14 @@ func TestIntegrationNoInlineIgnoreClean(t *testing.T) {
 		t.Fatalf("expected no findings, got %d", len(findings))
 	}
 }
+
+// TestIntegrationNoInlineIgnoreNilDocument ensures graceful handling of nil input.
+func TestIntegrationNoInlineIgnoreNilDocument(t *testing.T) {
+	r := NewNoInlineIgnore()
+	if findings, err := r.Check(context.Background(), nil); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", findings, err)
+	}
+	if findings, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", findings, err)
+	}
+}

--- a/internal/rules/DL3000_test.go
+++ b/internal/rules/DL3000_test.go
@@ -40,6 +40,27 @@ func TestIntegrationAbsoluteWorkdirViolation(t *testing.T) {
 	}
 }
 
+// TestIntegrationAbsoluteWorkdirDotRelative detects relative paths with leading dot.
+func TestIntegrationAbsoluteWorkdirDotRelative(t *testing.T) {
+	src := "FROM alpine\nWORKDIR ./app\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewAbsoluteWorkdir()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
 // TestIntegrationAbsoluteWorkdirClean ensures absolute paths pass.
 func TestIntegrationAbsoluteWorkdirClean(t *testing.T) {
 	src := "FROM alpine\nWORKDIR /app\n"

--- a/internal/rules/DL3001_test.go
+++ b/internal/rules/DL3001_test.go
@@ -82,6 +82,27 @@ func TestIntegrationNoIrrelevantCommandsConnector(t *testing.T) {
 	}
 }
 
+// TestIntegrationNoIrrelevantCommandsOrConnector handles OR connectors.
+func TestIntegrationNoIrrelevantCommandsOrConnector(t *testing.T) {
+	src := "FROM alpine\nRUN ssh localhost || echo hi\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewNoIrrelevantCommands()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
 // TestIntegrationNoIrrelevantCommandsClean ensures compliant Dockerfiles pass.
 func TestIntegrationNoIrrelevantCommandsClean(t *testing.T) {
 	src := "FROM alpine\nRUN echo hi\n"

--- a/internal/rules/DL3002_test.go
+++ b/internal/rules/DL3002_test.go
@@ -40,6 +40,27 @@ func TestIntegrationLastUserNotRootViolation(t *testing.T) {
 	}
 }
 
+// TestIntegrationLastUserNotRootGroup detects root with group specification.
+func TestIntegrationLastUserNotRootGroup(t *testing.T) {
+	src := "FROM alpine\nUSER root:root\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewLastUserNotRoot()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
 // TestIntegrationLastUserNotRootClean ensures compliant Dockerfiles pass.
 func TestIntegrationLastUserNotRootClean(t *testing.T) {
 	src := "FROM alpine\nUSER root\nUSER app\nRUN echo hi\nFROM busybox\nRUN echo hi\n"

--- a/internal/rules/DL3003_test.go
+++ b/internal/rules/DL3003_test.go
@@ -40,6 +40,27 @@ func TestIntegrationUseWorkdirViolation(t *testing.T) {
 	}
 }
 
+// TestIntegrationUseWorkdirConnector detects cd usage before another command.
+func TestIntegrationUseWorkdirConnector(t *testing.T) {
+	src := "FROM alpine\nRUN cd /tmp && ls\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewUseWorkdir()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
 // TestIntegrationUseWorkdirClean ensures compliant Dockerfiles pass.
 func TestIntegrationUseWorkdirClean(t *testing.T) {
 	src := "FROM alpine\nWORKDIR /tmp\nRUN echo hi\n"

--- a/internal/rules/DL3004_test.go
+++ b/internal/rules/DL3004_test.go
@@ -40,6 +40,27 @@ func TestIntegrationNoSudoViolation(t *testing.T) {
 	}
 }
 
+// TestIntegrationNoSudoExecForm detects sudo usage in JSON form.
+func TestIntegrationNoSudoExecForm(t *testing.T) {
+	src := "FROM alpine\nRUN [\"sudo\",\"echo\",\"hi\"]\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewNoSudo()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
 // TestIntegrationNoSudoClean ensures compliant Dockerfiles pass.
 func TestIntegrationNoSudoClean(t *testing.T) {
 	src := "FROM alpine\nRUN echo hi\n"

--- a/internal/rules/DL3006_test.go
+++ b/internal/rules/DL3006_test.go
@@ -63,6 +63,22 @@ func TestIntegrationRequireTagClean(t *testing.T) {
 	}
 }
 
+// TestIntegrationRequireTagScratchAndVariable allows scratch and variable images.
+func TestIntegrationRequireTagScratchAndVariable(t *testing.T) {
+	r := NewRequireTag()
+	doc := &ir.Document{Stages: []*ir.Stage{
+		{Index: 0, From: "scratch", Node: &parser.Node{StartLine: 1}},
+		{Index: 1, From: "$BASE", Node: &parser.Node{StartLine: 2}},
+	}}
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
 // TestIntegrationRequireTagNilDocument ensures graceful handling of nil input.
 func TestIntegrationRequireTagNilDocument(t *testing.T) {
 	r := NewRequireTag()

--- a/internal/rules/DL3007_test.go
+++ b/internal/rules/DL3007_test.go
@@ -46,3 +46,15 @@ func TestIntegrationNoLatestTagClean(t *testing.T) {
 		t.Fatalf("expected no findings, got %d", len(findings))
 	}
 }
+
+// TestIntegrationNoLatestTagEmptyDocument ensures empty docs pass.
+func TestIntegrationNoLatestTagEmptyDocument(t *testing.T) {
+	r := NewNoLatestTag()
+	findings, err := r.Check(context.Background(), &ir.Document{})
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}

--- a/internal/rules/DL3008_test.go
+++ b/internal/rules/DL3008_test.go
@@ -40,6 +40,27 @@ func TestIntegrationAptPinViolation(t *testing.T) {
 	}
 }
 
+// TestIntegrationAptPinMissingVersion detects packages with empty version.
+func TestIntegrationAptPinMissingVersion(t *testing.T) {
+	r := NewAptPin()
+	src := "FROM ubuntu\nRUN apt-get install curl= ca-certificates=1.2\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+}
+
 // TestIntegrationAptPinClean ensures compliant installs pass.
 func TestIntegrationAptPinClean(t *testing.T) {
 	r := NewAptPin()
@@ -53,6 +74,18 @@ func TestIntegrationAptPinClean(t *testing.T) {
 		t.Fatalf("build document: %v", err)
 	}
 	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationAptPinEmptyDocument ensures empty documents pass.
+func TestIntegrationAptPinEmptyDocument(t *testing.T) {
+	r := NewAptPin()
+	findings, err := r.Check(context.Background(), &ir.Document{})
 	if err != nil {
 		t.Fatalf("check failed: %v", err)
 	}

--- a/internal/rules/DL3009_test.go
+++ b/internal/rules/DL3009_test.go
@@ -61,6 +61,27 @@ func TestIntegrationAptListsCleanupClean(t *testing.T) {
 	}
 }
 
+// TestIntegrationAptListsCleanupFindDelete uses find -delete for cleanup.
+func TestIntegrationAptListsCleanupFindDelete(t *testing.T) {
+	src := "FROM ubuntu\nRUN apt-get install -y curl && find /var/lib/apt/lists -delete\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewAptListsCleanup()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
 // TestIntegrationAptListsCleanupCleanOnly verifies apt-get clean is insufficient.
 func TestIntegrationAptListsCleanupCleanOnly(t *testing.T) {
 	src := "FROM ubuntu\nRUN apt-get update && apt-get install -y curl && apt-get clean\n"

--- a/internal/rules/DL3010_test.go
+++ b/internal/rules/DL3010_test.go
@@ -40,6 +40,27 @@ func TestIntegrationUseADDForArchivesViolation(t *testing.T) {
 	}
 }
 
+// TestIntegrationUseADDForArchivesFileDest ignores archives copied to file paths.
+func TestIntegrationUseADDForArchivesFileDest(t *testing.T) {
+	src := "FROM alpine\nCOPY app.tar.gz /opt/app.tar.gz\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewUseADDForArchives()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
 // TestIntegrationUseADDForArchivesClean ensures compliant Dockerfiles pass.
 func TestIntegrationUseADDForArchivesClean(t *testing.T) {
 	src := "FROM alpine\nCOPY app.txt /opt/\n"

--- a/internal/rules/DL3011_test.go
+++ b/internal/rules/DL3011_test.go
@@ -61,6 +61,27 @@ func TestIntegrationValidPortRangeClean(t *testing.T) {
 	}
 }
 
+// TestIntegrationValidPortRangeNamedPort ensures non-numeric ports are ignored.
+func TestIntegrationValidPortRangeNamedPort(t *testing.T) {
+	src := "FROM alpine\nEXPOSE http 80\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewValidPortRange()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
 // TestIntegrationValidPortRangeNilDocument ensures graceful handling of nil input.
 func TestIntegrationValidPortRangeNilDocument(t *testing.T) {
 	r := NewValidPortRange()


### PR DESCRIPTION
## Summary
- add nil document handling tests for DL1001 and various DL3xxx rules
- exercise additional edge cases such as connectors, exec form, and special image sources

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689eac1f79248332a1c7511fd910520e