### PR TITLE
refactor: centralize RUN segment parsing

### DIFF
--- a/internal/rules/run_commands.go
+++ b/internal/rules/run_commands.go
@@ -48,3 +48,53 @@ func commandNames(tokens []string) []string {
 	}
 	return cmds
 }
+
+// splitRunSegments tokenizes a RUN instruction and splits it into command segments.
+// It handles both shell-form and JSON-form RUN instructions.
+func splitRunSegments(n *parser.Node) [][]string {
+	if n == nil || n.Next == nil {
+		return nil
+	}
+	var tokens []string
+	if n.Attributes != nil && n.Attributes["json"] {
+		for tok := n.Next; tok != nil; tok = tok.Next {
+			tokens = append(tokens, tok.Value)
+		}
+	} else {
+		t, err := shlex.Split(n.Next.Value)
+		if err != nil {
+			return nil
+		}
+		tokens = t
+	}
+	var segments [][]string
+	var current []string
+	for _, tok := range tokens {
+		switch tok {
+		case "&&", "||", "|", ";":
+			if len(current) > 0 {
+				segments = append(segments, current)
+				current = nil
+			}
+		default:
+			current = append(current, tok)
+		}
+	}
+	if len(current) > 0 {
+		segments = append(segments, current)
+	}
+	return segments
+}
+
+// lowerSegments returns a lowercase copy of each segment.
+func lowerSegments(segs [][]string) [][]string {
+	out := make([][]string, len(segs))
+	for i, seg := range segs {
+		outSeg := make([]string, len(seg))
+		for j, s := range seg {
+			outSeg[j] = strings.ToLower(s)
+		}
+		out[i] = outSeg
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- centralize RUN instruction segment parsing and lowercasing helpers
- update apt cleanup rule to use new segment utilities
- rename npm package version check helper to avoid conflicts

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689eade2df888332bae813515f291733