### PR TITLE
feat: implement DL3029 rule to block FROM --platform

### DIFF
--- a/docs/rules/DL3029.md
+++ b/docs/rules/DL3029.md
@@ -1,0 +1,6 @@
+# DL3029 - Do not use --platform flag with FROM
+
+Avoid specifying a fixed platform in `FROM` instructions. Use build environment
+variables like `$BUILDPLATFORM` or `$TARGETPLATFORM` instead of hardcoding
+platforms.
+

--- a/internal/rules/DL3029.go
+++ b/internal/rules/DL3029.go
@@ -1,0 +1,48 @@
+// file: internal/rules/DL3029.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// noPlatformInFrom disallows explicit --platform in FROM.
+type noPlatformInFrom struct{}
+
+// NewNoPlatformInFrom constructs the rule.
+func NewNoPlatformInFrom() engine.Rule { return noPlatformInFrom{} }
+
+// ID returns the rule identifier.
+func (noPlatformInFrom) ID() string { return "DL3029" }
+
+// Check warns on --platform usage in FROM instructions.
+func (noPlatformInFrom) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "from") {
+			continue
+		}
+		for _, f := range n.Flags {
+			if strings.HasPrefix(strings.ToLower(f), "--platform=") {
+				v := strings.TrimPrefix(f, "--platform=")
+				v = strings.Trim(v, "\"'")
+				if !strings.Contains(v, "BUILDPLATFORM") && !strings.Contains(v, "TARGETPLATFORM") {
+					findings = append(findings, engine.Finding{
+						RuleID:  "DL3029",
+						Message: "Do not use --platform flag with FROM",
+						Line:    n.StartLine,
+					})
+				}
+				break
+			}
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/DL3029_test.go
+++ b/internal/rules/DL3029_test.go
@@ -1,0 +1,73 @@
+// file: internal/rules/DL3029_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationNoPlatformInFromID validates rule identity.
+func TestIntegrationNoPlatformInFromID(t *testing.T) {
+	if NewNoPlatformInFrom().ID() != "DL3029" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationNoPlatformInFromViolation detects forbidden platform flag.
+func TestIntegrationNoPlatformInFromViolation(t *testing.T) {
+	src := "FROM --platform=linux/amd64 alpine\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewNoPlatformInFrom()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationNoPlatformInFromAllowed ensures build variables pass.
+func TestIntegrationNoPlatformInFromAllowed(t *testing.T) {
+	src := "FROM --platform=$TARGETPLATFORM alpine\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewNoPlatformInFrom()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationNoPlatformInFromNil ensures graceful handling of nil input.
+func TestIntegrationNoPlatformInFromNil(t *testing.T) {
+	r := NewNoPlatformInFrom()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add DL3029 rule forbidding fixed `--platform` values in `FROM`
- document DL3029
- add tests for DL3029

## Testing
- `go test ./...` *(fails: splitRunSegments redeclared in DL3016.go and DL3009.go)*

------
https://chatgpt.com/codex/tasks/task_b_689eaea0239083328c3af8d1c56906de