### PR TITLE
Implement DL4001 rule to avoid mixing curl and wget

### DIFF
--- a/docs/rules/DL4001.md
+++ b/docs/rules/DL4001.md
@@ -1,0 +1,3 @@
+# DL4001 - Either use Wget or Curl but not both
+
+Avoid installing or invoking both `curl` and `wget` in the same stage. Choose a single tool to reduce image size and complexity.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -18,4 +18,5 @@ The following Hadolint-compatible rules are implemented:
 - [DL3020](DL3020.md) - Use COPY instead of ADD for files and folders.
 - [DL3021](DL3021.md) - COPY with more than 2 arguments requires the last argument to end with /.
 - [DL4000](DL4000.md) - `MAINTAINER` is deprecated. Use `LABEL maintainer` instead.
+- [DL4001](DL4001.md) - Either use Wget or Curl but not both.
 

--- a/internal/rules/DL4001.go
+++ b/internal/rules/DL4001.go
@@ -1,0 +1,65 @@
+// file: internal/rules/DL4001.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// exclusiveCurlWget ensures only one of curl or wget is used per stage.
+type exclusiveCurlWget struct{}
+
+// NewExclusiveCurlWget constructs the rule.
+func NewExclusiveCurlWget() engine.Rule { return exclusiveCurlWget{} }
+
+// ID returns the rule identifier.
+func (exclusiveCurlWget) ID() string { return "DL4001" }
+
+// Check scans RUN instructions for mixed use of curl and wget.
+func (exclusiveCurlWget) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	seenCurl := false
+	seenWget := false
+	for _, n := range d.AST.Children {
+		if strings.EqualFold(n.Value, "from") {
+			seenCurl = false
+			seenWget = false
+			continue
+		}
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		cmds := extractCommands(n)
+		usesCurl := false
+		usesWget := false
+		for _, cmd := range cmds {
+			switch cmd {
+			case "curl":
+				usesCurl = true
+			case "wget":
+				usesWget = true
+			}
+		}
+		if usesCurl && usesWget || (usesCurl && seenWget) || (usesWget && seenCurl) {
+			findings = append(findings, engine.Finding{
+				RuleID:  "DL4001",
+				Message: "Either use Wget or Curl but not both",
+				Line:    n.StartLine,
+			})
+		}
+		if usesCurl {
+			seenCurl = true
+		}
+		if usesWget {
+			seenWget = true
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/DL4001_test.go
+++ b/internal/rules/DL4001_test.go
@@ -1,0 +1,115 @@
+// file: internal/rules/DL4001_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationExclusiveCurlWgetID validates rule identity.
+func TestIntegrationExclusiveCurlWgetID(t *testing.T) {
+	if NewExclusiveCurlWget().ID() != "DL4001" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationExclusiveCurlWgetViolation detects mixing curl and wget across RUNs.
+func TestIntegrationExclusiveCurlWgetViolation(t *testing.T) {
+	src := "FROM alpine\nRUN curl -L http://example.com\nRUN wget http://example.com\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewExclusiveCurlWget()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 || findings[0].Line != 3 {
+		t.Fatalf("expected one finding on line 3, got %#v", findings)
+	}
+}
+
+// TestIntegrationExclusiveCurlWgetSameRun flags using curl and wget in a single RUN.
+func TestIntegrationExclusiveCurlWgetSameRun(t *testing.T) {
+	src := "FROM alpine\nRUN wget http://a && curl http://b\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewExclusiveCurlWget()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 || findings[0].Line != 2 {
+		t.Fatalf("expected one finding on line 2, got %#v", findings)
+	}
+}
+
+// TestIntegrationExclusiveCurlWgetCleanSingleTool allows repeated use of one tool.
+func TestIntegrationExclusiveCurlWgetCleanSingleTool(t *testing.T) {
+	src := "FROM alpine\nRUN curl -L http://a\nRUN curl -L http://b\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewExclusiveCurlWget()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationExclusiveCurlWgetCleanSeparateStages permits different tools per stage.
+func TestIntegrationExclusiveCurlWgetCleanSeparateStages(t *testing.T) {
+	src := "FROM alpine\nRUN curl -L http://a\nFROM alpine\nRUN wget http://b\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewExclusiveCurlWget()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationExclusiveCurlWgetNilDocument ensures graceful handling of nil input.
+func TestIntegrationExclusiveCurlWgetNilDocument(t *testing.T) {
+	r := NewExclusiveCurlWget()
+	if findings, err := r.Check(context.Background(), nil); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", findings, err)
+	}
+	if findings, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", findings, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add DL4001 rule preventing use of both curl and wget in the same stage
- document DL4001 and reference it in the rules list
- cover rule behavior with dedicated tests

## Testing
- `go test ./...` *(fails: splitRunSegments redeclared in DL3016.go and DL3009.go)*

------
https://chatgpt.com/codex/tasks/task_b_689eb014151883329dac5dde9d8a883f