### PR TITLE
feat: enforce SHELL for default shell

### DIFF
--- a/docs/rules/DL4005.md
+++ b/docs/rules/DL4005.md
@@ -1,0 +1,3 @@
+# DL4005 - Use SHELL to change the default shell
+
+Changing the default shell by linking to `/bin/sh` within a `RUN` instruction is discouraged. Use the `SHELL` directive to specify a different default shell for subsequent commands.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -18,4 +18,5 @@ The following Hadolint-compatible rules are implemented:
 - [DL3020](DL3020.md) - Use COPY instead of ADD for files and folders.
 - [DL3021](DL3021.md) - COPY with more than 2 arguments requires the last argument to end with /.
 - [DL4000](DL4000.md) - `MAINTAINER` is deprecated. Use `LABEL maintainer` instead.
+- [DL4005](DL4005.md) - Use SHELL to change the default shell.
 

--- a/internal/rules/DL4005.go
+++ b/internal/rules/DL4005.go
@@ -1,0 +1,62 @@
+// file: internal/rules/DL4005.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// useShellForDefault warns when RUN is used to change the default shell.
+type useShellForDefault struct{}
+
+// NewUseShellForDefault constructs the rule.
+func NewUseShellForDefault() engine.Rule { return useShellForDefault{} }
+
+// ID returns the rule identifier.
+func (useShellForDefault) ID() string { return "DL4005" }
+
+// Check scans RUN instructions for ln commands targeting /bin/sh.
+func (useShellForDefault) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		tokens := runTokens(n)
+		cmds := splitTokens(tokens)
+		for _, cmd := range cmds {
+			if lnTargetsBinSh(cmd) {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL4005",
+					Message: "Use SHELL to change the default shell",
+					Line:    n.StartLine,
+				})
+				break
+			}
+		}
+	}
+	return findings, nil
+}
+
+// lnTargetsBinSh reports ln invocations altering /bin/sh.
+func lnTargetsBinSh(tokens []string) bool {
+	if len(tokens) == 0 {
+		return false
+	}
+	if strings.ToLower(tokens[0]) != "ln" {
+		return false
+	}
+	for _, t := range tokens[1:] {
+		if strings.Trim(t, "\"'") == "/bin/sh" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rules/DL4005_test.go
+++ b/internal/rules/DL4005_test.go
@@ -1,0 +1,94 @@
+// file: internal/rules/DL4005_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationUseShellForDefaultID validates rule identity.
+func TestIntegrationUseShellForDefaultID(t *testing.T) {
+	if NewUseShellForDefault().ID() != "DL4005" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationUseShellForDefaultViolation detects linking /bin/sh via RUN.
+func TestIntegrationUseShellForDefaultViolation(t *testing.T) {
+	src := "FROM alpine\nRUN ln -sf /bin/bash /bin/sh\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewUseShellForDefault()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 || findings[0].Line != 2 {
+		t.Fatalf("expected one finding on line 2, got %#v", findings)
+	}
+}
+
+// TestIntegrationUseShellForDefaultClean ensures proper SHELL usage passes.
+func TestIntegrationUseShellForDefaultClean(t *testing.T) {
+	src := "FROM alpine\nSHELL [\"/bin/bash\", \"-c\"]\nRUN echo hi\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewUseShellForDefault()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationUseShellForDefaultChained detects ln within command chains.
+func TestIntegrationUseShellForDefaultChained(t *testing.T) {
+	src := "FROM alpine\nRUN echo hi && ln -s /bin/bash /bin/sh\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewUseShellForDefault()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationUseShellForDefaultNilDocument ensures nil documents are handled.
+func TestIntegrationUseShellForDefaultNilDocument(t *testing.T) {
+	r := NewUseShellForDefault()
+	if findings, err := r.Check(context.Background(), nil); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", findings, err)
+	}
+	if findings, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", findings, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add DL4005 rule detecting `RUN ln ... /bin/sh`
- document DL4005 rule and list in rule index

## Testing
- `go test ./...` *(fails: splitRunSegments and versionFixed redeclared in existing packages)*

------
https://chatgpt.com/codex/tasks/task_b_689eb03e6818833291ca8af1b2d125ab