### PR TITLE
Add DL4006 rule requiring pipefail before pipeline RUN commands

### DIFF
--- a/docs/rules/DL4006.md
+++ b/docs/rules/DL4006.md
@@ -1,0 +1,4 @@
+# DL4006 - Set the SHELL option -o pipefail before RUN with a pipe in it
+
+Set the `SHELL` option `-o pipefail` before a `RUN` instruction containing a pipe. Without `pipefail`, errors in piped commands might be masked. If you are using `/bin/sh` in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your `SHELL` to `/bin/ash`, or disable this check.
+

--- a/internal/rules/DL4006.go
+++ b/internal/rules/DL4006.go
@@ -1,0 +1,101 @@
+// file: internal/rules/DL4006.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// pipefailBeforePipe flags RUN instructions with pipes without preceding SHELL -o pipefail.
+type pipefailBeforePipe struct{}
+
+// NewPipefailBeforePipe constructs the rule.
+func NewPipefailBeforePipe() engine.Rule { return pipefailBeforePipe{} }
+
+// ID returns the rule identifier.
+func (pipefailBeforePipe) ID() string { return "DL4006" }
+
+// Check evaluates the Dockerfile for missing pipefail.
+func (pipefailBeforePipe) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	pipefail := false
+	nonPosix := []string{"pwsh", "powershell", "cmd"}
+	valid := map[string]bool{"/bin/bash": true, "/bin/zsh": true, "/bin/ash": true, "bash": true, "zsh": true, "ash": true}
+	for _, n := range d.AST.Children {
+		switch strings.ToLower(n.Value) {
+		case "from":
+			pipefail = false
+		case "shell":
+			if isNonPosixShell(n, nonPosix) {
+				pipefail = true
+			} else {
+				pipefail = hasPipefailOption(n, valid)
+			}
+		case "run":
+			if !pipefail && runHasPipe(n) {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL4006",
+					Message: "Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check",
+					Line:    n.StartLine,
+				})
+			}
+		}
+	}
+	return findings, nil
+}
+
+// isNonPosixShell reports whether the shell is non-POSIX and thus exempt.
+func isNonPosixShell(n *parser.Node, shells []string) bool {
+	if n == nil || n.Next == nil {
+		return false
+	}
+	sh := strings.ToLower(n.Next.Value)
+	for _, s := range shells {
+		if strings.HasPrefix(sh, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasPipefailOption checks for -o pipefail in a SHELL instruction.
+func hasPipefailOption(n *parser.Node, valid map[string]bool) bool {
+	if n == nil || n.Next == nil {
+		return false
+	}
+	sh := strings.ToLower(n.Next.Value)
+	if !valid[sh] {
+		return false
+	}
+	for t := n.Next.Next; t != nil; t = t.Next {
+		if t.Value == "-o" && t.Next != nil && strings.EqualFold(t.Next.Value, "pipefail") {
+			return true
+		}
+	}
+	return false
+}
+
+// runHasPipe detects whether a RUN command contains a pipe.
+func runHasPipe(n *parser.Node) bool {
+	if n == nil || n.Next == nil {
+		return false
+	}
+	if n.Attributes != nil && n.Attributes["json"] {
+		for t := n.Next; t != nil; t = t.Next {
+			if strings.Contains(t.Value, "|") {
+				return true
+			}
+		}
+		return false
+	}
+	return strings.Contains(n.Next.Value, "|")
+}

--- a/internal/rules/DL4006_test.go
+++ b/internal/rules/DL4006_test.go
@@ -1,0 +1,136 @@
+// file: internal/rules/DL4006_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationPipefailBeforePipeID validates rule identity.
+func TestIntegrationPipefailBeforePipeID(t *testing.T) {
+	if NewPipefailBeforePipe().ID() != "DL4006" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationPipefailBeforePipeViolation warns on pipelines without pipefail.
+func TestIntegrationPipefailBeforePipeViolation(t *testing.T) {
+	src := "FROM alpine\nRUN echo hi | grep h\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewPipefailBeforePipe()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 || findings[0].Line != 2 {
+		t.Fatalf("expected one finding on line 2, got %#v", findings)
+	}
+}
+
+// TestIntegrationPipefailBeforePipeClean ensures pipefail option suppresses warning.
+func TestIntegrationPipefailBeforePipeClean(t *testing.T) {
+	src := "FROM alpine\nSHELL [\"/bin/bash\",\"-o\",\"pipefail\",\"-c\"]\nRUN echo hi | grep h\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewPipefailBeforePipe()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationPipefailBeforePipeNoPipe ignores commands without pipes.
+func TestIntegrationPipefailBeforePipeNoPipe(t *testing.T) {
+	src := "FROM alpine\nRUN echo hi && grep h file\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewPipefailBeforePipe()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationPipefailBeforePipeNonPosixShell ignores non-POSIX shells.
+func TestIntegrationPipefailBeforePipeNonPosixShell(t *testing.T) {
+	src := "FROM scratch\nSHELL [\"pwsh\",\"-c\"]\nRUN Get-Item a | Select-Object\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewPipefailBeforePipe()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationPipefailBeforePipeReset verifies state resets on new FROM.
+func TestIntegrationPipefailBeforePipeReset(t *testing.T) {
+	src := "FROM alpine\nSHELL [\"/bin/bash\",\"-o\",\"pipefail\",\"-c\"]\nRUN echo hi | grep h\nFROM alpine\nRUN echo hi | grep h\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewPipefailBeforePipe()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 || findings[0].Line != 5 {
+		t.Fatalf("expected one finding on line 5, got %#v", findings)
+	}
+}
+
+// TestIntegrationPipefailBeforePipeNil handles nil documents gracefully.
+func TestIntegrationPipefailBeforePipeNil(t *testing.T) {
+	r := NewPipefailBeforePipe()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add rule DL4006 enforcing `SHELL -o pipefail` before `RUN` instructions with pipes
- document DL4006 usage and intent
- cover rule behavior with unit tests

## Testing
- `go test ./...` *(fails: splitRunSegments redeclared in this block)*

------
https://chatgpt.com/codex/tasks/task_b_689eb051fc208332a596f232cdc0f37b