### PR TITLE
Add rule DL4004: limit ENTRYPOINT to one per stage

### DIFF
--- a/docs/rules/DL4004.md
+++ b/docs/rules/DL4004.md
@@ -1,0 +1,4 @@
+# DL4004 - Multiple ENTRYPOINT instructions
+
+Listing more than one `ENTRYPOINT` instruction in a single stage means only the last takes effect. Remove redundant `ENTRYPOINT` directives to avoid confusion.
+

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -19,3 +19,4 @@ The following Hadolint-compatible rules are implemented:
 - [DL3021](DL3021.md) - COPY with more than 2 arguments requires the last argument to end with /.
 - [DL4000](DL4000.md) - `MAINTAINER` is deprecated. Use `LABEL maintainer` instead.
 
+- [DL4004](DL4004.md) - Avoid multiple ENTRYPOINT instructions.

--- a/internal/rules/DL4004.go
+++ b/internal/rules/DL4004.go
@@ -1,0 +1,47 @@
+// file: internal/rules/DL4004.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// singleEntrypoint ensures each build stage defines at most one ENTRYPOINT.
+type singleEntrypoint struct{}
+
+// NewSingleEntrypoint constructs the rule.
+func NewSingleEntrypoint() engine.Rule { return singleEntrypoint{} }
+
+// ID returns the rule identifier.
+func (singleEntrypoint) ID() string { return "DL4004" }
+
+// Check scans stages for multiple ENTRYPOINT instructions.
+func (singleEntrypoint) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	hasEntrypoint := false
+	for _, n := range d.AST.Children {
+		if strings.EqualFold(n.Value, "from") {
+			hasEntrypoint = false
+			continue
+		}
+		if strings.EqualFold(n.Value, "entrypoint") {
+			if hasEntrypoint {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL4004",
+					Message: "Multiple `ENTRYPOINT` instructions found. If you list more than one `ENTRYPOINT` then only the last `ENTRYPOINT` will take effect",
+					Line:    n.StartLine,
+				})
+			} else {
+				hasEntrypoint = true
+			}
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/DL4004_test.go
+++ b/internal/rules/DL4004_test.go
@@ -1,0 +1,73 @@
+// file: internal/rules/DL4004_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationSingleEntrypointID validates rule identity.
+func TestIntegrationSingleEntrypointID(t *testing.T) {
+	if NewSingleEntrypoint().ID() != "DL4004" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationSingleEntrypointViolation detects multiple ENTRYPOINT instructions in a stage.
+func TestIntegrationSingleEntrypointViolation(t *testing.T) {
+	src := "FROM alpine\nENTRYPOINT [\"/bin/ls\"]\nENTRYPOINT [\"/bin/sh\"]\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewSingleEntrypoint()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 || findings[0].Line != 3 {
+		t.Fatalf("expected one finding on line 3, got %#v", findings)
+	}
+}
+
+// TestIntegrationSingleEntrypointSeparateStages allows ENTRYPOINT per stage.
+func TestIntegrationSingleEntrypointSeparateStages(t *testing.T) {
+	src := "FROM alpine\nENTRYPOINT [\"/bin/ls\"]\nFROM ubuntu\nENTRYPOINT [\"/bin/bash\"]\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewSingleEntrypoint()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationSingleEntrypointNilDocument ensures graceful handling of nil input.
+func TestIntegrationSingleEntrypointNilDocument(t *testing.T) {
+	r := NewSingleEntrypoint()
+	if findings, err := r.Check(context.Background(), nil); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", findings, err)
+	}
+	if findings, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", findings, err)
+	}
+}


### PR DESCRIPTION
## Summary
- implement DL4004 rule to report multiple ENTRYPOINT instructions in the same stage
- cover rule with integration tests
- document rule in docs/rules and list in rule index

## Testing
- `go test ./...` *(fails: splitRunSegments redeclared in DL3016.go, versionFixed redeclared in DL3016.go)*

------
https://chatgpt.com/codex/tasks/task_b_689eb02fd5608332b186408cf9a7daab