### PR TITLE
Add DL4003 rule for multiple CMD instructions

### DIFF
--- a/docs/rules/DL4003.md
+++ b/docs/rules/DL4003.md
@@ -1,0 +1,3 @@
+# DL4003 - Multiple CMD instructions
+
+Multiple `CMD` instructions found. If you list more than one `CMD` then only the last `CMD` will take effect.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -18,4 +18,5 @@ The following Hadolint-compatible rules are implemented:
 - [DL3020](DL3020.md) - Use COPY instead of ADD for files and folders.
 - [DL3021](DL3021.md) - COPY with more than 2 arguments requires the last argument to end with /.
 - [DL4000](DL4000.md) - `MAINTAINER` is deprecated. Use `LABEL maintainer` instead.
+- [DL4003](DL4003.md) - Multiple CMD instructions found. Only the last CMD takes effect.
 

--- a/internal/rules/DL4003.go
+++ b/internal/rules/DL4003.go
@@ -1,0 +1,47 @@
+// file: internal/rules/DL4003.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// singleCmd enforces a single CMD instruction per build stage.
+type singleCmd struct{}
+
+// NewSingleCmd constructs the rule.
+func NewSingleCmd() engine.Rule { return singleCmd{} }
+
+// ID returns the rule identifier.
+func (singleCmd) ID() string { return "DL4003" }
+
+// Check scans each stage for multiple CMD instructions.
+func (singleCmd) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	seen := false
+	for _, n := range d.AST.Children {
+		if strings.EqualFold(n.Value, "from") {
+			seen = false
+			continue
+		}
+		if strings.EqualFold(n.Value, "cmd") {
+			if seen {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL4003",
+					Message: "Multiple CMD instructions found. If you list more than one CMD then only the last CMD will take effect",
+					Line:    n.StartLine,
+				})
+				continue
+			}
+			seen = true
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/DL4003_test.go
+++ b/internal/rules/DL4003_test.go
@@ -1,0 +1,136 @@
+// file: internal/rules/DL4003_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationSingleCmdID validates rule identity.
+func TestIntegrationSingleCmdID(t *testing.T) {
+	if NewSingleCmd().ID() != "DL4003" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationSingleCmdViolation detects multiple CMD instructions in a stage.
+func TestIntegrationSingleCmdViolation(t *testing.T) {
+	src := "FROM alpine\nCMD echo one\nCMD echo two\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewSingleCmd()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 || findings[0].Line != 3 {
+		t.Fatalf("expected one finding on line 3, got %#v", findings)
+	}
+}
+
+// TestIntegrationSingleCmdClean ensures a single CMD passes.
+func TestIntegrationSingleCmdClean(t *testing.T) {
+	src := "FROM alpine\nCMD echo one\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewSingleCmd()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationSingleCmdMultiStage validates each stage may have one CMD.
+func TestIntegrationSingleCmdMultiStage(t *testing.T) {
+	src := "FROM alpine\nCMD echo one\nFROM alpine\nCMD echo two\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewSingleCmd()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationSingleCmdMultiStageViolation flags extra CMD in later stage.
+func TestIntegrationSingleCmdMultiStageViolation(t *testing.T) {
+	src := "FROM alpine\nCMD echo one\nFROM alpine\nCMD echo two\nCMD echo three\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewSingleCmd()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 || findings[0].Line != 5 {
+		t.Fatalf("expected one finding on line 5, got %#v", findings)
+	}
+}
+
+// TestIntegrationSingleCmdCaseInsensitive ensures lowercase cmd is detected.
+func TestIntegrationSingleCmdCaseInsensitive(t *testing.T) {
+	src := "FROM alpine\ncmd echo one\ncmd echo two\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewSingleCmd()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 || findings[0].Line != 3 {
+		t.Fatalf("expected one finding on line 3, got %#v", findings)
+	}
+}
+
+// TestIntegrationSingleCmdNilDocument ensures graceful handling of nil input.
+func TestIntegrationSingleCmdNilDocument(t *testing.T) {
+	r := NewSingleCmd()
+	if findings, err := r.Check(context.Background(), nil); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", findings, err)
+	}
+	if findings, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", findings, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add DL4003 rule to detect multiple CMD instructions per stage
- document DL4003 in rule docs
- test coverage for DL4003 including multi-stage and case-insensitive scenarios

## Testing
- `go test ./...` *(fails: splitRunSegments redeclared, versionFixed redeclared)*
- `go test internal/rules/DL4003_test.go internal/rules/DL4003.go internal/rules/run_commands.go internal/rules/stage_utils.go`


------
https://chatgpt.com/codex/tasks/task_b_689eb02443788332a1bd1129ab0ac792