### PR TITLE
Add DL3061 rule for initial instruction order

### DIFF
--- a/docs/rules/DL3061.md
+++ b/docs/rules/DL3061.md
@@ -1,0 +1,3 @@
+# DL3061 - Dockerfile must start with FROM or ARG
+
+Invalid instruction order. Dockerfile must begin with `FROM`, `ARG` or comment.

--- a/internal/rules/DL3061.go
+++ b/internal/rules/DL3061.go
@@ -1,0 +1,37 @@
+// file: internal/rules/DL3061.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// startWithFromOrArg ensures the Dockerfile begins with FROM or ARG.
+type startWithFromOrArg struct{}
+
+// NewStartWithFromOrArg constructs the rule.
+func NewStartWithFromOrArg() engine.Rule { return startWithFromOrArg{} }
+
+// ID returns the rule identifier.
+func (startWithFromOrArg) ID() string { return "DL3061" }
+
+// Check verifies that the first instruction is FROM or ARG.
+func (startWithFromOrArg) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil || len(d.AST.Children) == 0 {
+		return findings, nil
+	}
+	first := d.AST.Children[0]
+	if !strings.EqualFold(first.Value, "from") && !strings.EqualFold(first.Value, "arg") {
+		findings = append(findings, engine.Finding{
+			RuleID:  "DL3061",
+			Message: "Invalid instruction order. Dockerfile must begin with `FROM`, `ARG` or comment.",
+			Line:    first.StartLine,
+		})
+	}
+	return findings, nil
+}

--- a/internal/rules/DL3061_test.go
+++ b/internal/rules/DL3061_test.go
@@ -1,0 +1,94 @@
+// file: internal/rules/DL3061_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationStartWithFromOrArgID validates rule identity.
+func TestIntegrationStartWithFromOrArgID(t *testing.T) {
+	if NewStartWithFromOrArg().ID() != "DL3061" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationStartWithFromOrArgViolation detects invalid first instructions.
+func TestIntegrationStartWithFromOrArgViolation(t *testing.T) {
+	src := "# comment\nRUN echo hi\nFROM alpine\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewStartWithFromOrArg()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationStartWithFromOrArgCleanFrom ensures FROM starts pass.
+func TestIntegrationStartWithFromOrArgCleanFrom(t *testing.T) {
+	src := "# comment\nFROM alpine\nRUN echo hi\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewStartWithFromOrArg()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationStartWithFromOrArgCleanArg ensures ARG starts pass.
+func TestIntegrationStartWithFromOrArgCleanArg(t *testing.T) {
+	src := "ARG BASE=alpine\nFROM $BASE\nRUN echo hi\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewStartWithFromOrArg()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationStartWithFromOrArgNil ensures graceful handling of nil input.
+func TestIntegrationStartWithFromOrArgNil(t *testing.T) {
+	r := NewStartWithFromOrArg()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add DL3061 to ensure Dockerfiles start with `FROM` or `ARG`
- document DL3061 rule
- test invalid and valid initial instruction scenarios

## Testing
- `go test ./...` *(fails: splitRunSegments redeclared)*


------
https://chatgpt.com/codex/tasks/task_b_689eafd05bb08332b0c1ff4e67c02ed5