### PR TITLE
feat: add yarn cache clean rule

### DIFF
--- a/docs/rules/DL3060.md
+++ b/docs/rules/DL3060.md
@@ -1,0 +1,3 @@
+# DL3060 - `yarn cache clean` missing after `yarn install`
+
+Run commands that execute `yarn install` should also clean the yarn cache in the same layer, unless a BuildKit cache mount is used.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -17,5 +17,6 @@ The following Hadolint-compatible rules are implemented:
 - [DL3019](DL3019.md) - Use --no-cache with apk add.
 - [DL3020](DL3020.md) - Use COPY instead of ADD for files and folders.
 - [DL3021](DL3021.md) - COPY with more than 2 arguments requires the last argument to end with /.
+- [DL3060](DL3060.md) - `yarn cache clean` missing after `yarn install`.
 - [DL4000](DL4000.md) - `MAINTAINER` is deprecated. Use `LABEL maintainer` instead.
 

--- a/internal/rules/DL3016.go
+++ b/internal/rules/DL3016.go
@@ -35,7 +35,7 @@ func (pinNpmVersion) Check(ctx context.Context, d *ir.Document) ([]engine.Findin
 		if !strings.EqualFold(n.Value, "run") {
 			continue
 		}
-		segments := splitRunSegments(n)
+		segments := splitRunSegmentsNpm(n)
 		for _, seg := range segments {
 			if len(seg) == 0 {
 				continue
@@ -94,8 +94,8 @@ func npmInstallPackages(tokens []string) []string {
 	return packages
 }
 
-// splitRunSegments tokenizes a RUN node and splits it into command segments.
-func splitRunSegments(n *parser.Node) [][]string {
+// splitRunSegmentsNpm tokenizes a RUN node and splits it into command segments.
+func splitRunSegmentsNpm(n *parser.Node) [][]string {
 	if n == nil || n.Next == nil {
 		return nil
 	}
@@ -133,15 +133,15 @@ func splitRunSegments(n *parser.Node) [][]string {
 // allVersionFixed returns true if all packages specify a version, tag, or commit.
 func allVersionFixed(pkgs []string) bool {
 	for _, p := range pkgs {
-		if !versionFixed(p) {
+		if !npmVersionFixed(p) {
 			return false
 		}
 	}
 	return true
 }
 
-// versionFixed determines if a package argument is pinned to a version.
-func versionFixed(pkg string) bool {
+// npmVersionFixed determines if a package argument is pinned to a version.
+func npmVersionFixed(pkg string) bool {
 	if hasGitPrefix(pkg) {
 		return isVersionedGit(pkg)
 	}

--- a/internal/rules/DL3060.go
+++ b/internal/rules/DL3060.go
@@ -1,0 +1,109 @@
+package rules
+
+/*
+ * file: internal/rules/DL3060.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/shlex"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// yarnCacheClean ensures yarn cache is cleaned after yarn install.
+type yarnCacheClean struct{}
+
+// NewYarnCacheClean constructs the rule.
+func NewYarnCacheClean() engine.Rule { return yarnCacheClean{} }
+
+// ID returns the rule identifier.
+func (yarnCacheClean) ID() string { return "DL3060" }
+
+// Check warns when `yarn install` is used without subsequent `yarn cache clean`.
+func (yarnCacheClean) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		if hasCacheMount(n.Flags) {
+			continue
+		}
+		if n.Next == nil {
+			continue
+		}
+		tokens, err := shlex.Split(n.Next.Value)
+		if err != nil {
+			continue
+		}
+		segments := splitByConnectors(tokens)
+		install := false
+		clean := false
+		for _, seg := range segments {
+			if isYarnInstall(seg) {
+				install = true
+			}
+			if isYarnCacheClean(seg) {
+				clean = true
+			}
+		}
+		if install && !clean {
+			findings = append(findings, engine.Finding{
+				RuleID:  "DL3060",
+				Message: "`yarn cache clean` missing after `yarn install` was run.",
+				Line:    n.StartLine,
+			})
+		}
+	}
+	return findings, nil
+}
+
+// hasCacheMount reports whether a cache mount is present.
+func hasCacheMount(flags []string) bool {
+	for _, f := range flags {
+		lf := strings.ToLower(f)
+		if !strings.HasPrefix(lf, "--mount=") {
+			continue
+		}
+		opts := strings.Split(strings.TrimPrefix(lf, "--mount="), ",")
+		for _, o := range opts {
+			if strings.HasPrefix(o, "type=") && strings.TrimPrefix(o, "type=") == "cache" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isYarnInstall reports whether tokens represent `yarn install`.
+func isYarnInstall(tokens []string) bool {
+	if len(tokens) < 2 {
+		return false
+	}
+	if strings.ToLower(tokens[0]) != "yarn" {
+		return false
+	}
+	return strings.ToLower(tokens[1]) == "install"
+}
+
+// isYarnCacheClean reports whether tokens represent `yarn cache clean`.
+func isYarnCacheClean(tokens []string) bool {
+	if len(tokens) < 3 {
+		return false
+	}
+	if strings.ToLower(tokens[0]) != "yarn" {
+		return false
+	}
+	if strings.ToLower(tokens[1]) != "cache" {
+		return false
+	}
+	return strings.ToLower(tokens[2]) == "clean"
+}

--- a/internal/rules/DL3060_test.go
+++ b/internal/rules/DL3060_test.go
@@ -1,0 +1,94 @@
+// file: internal/rules/DL3060_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationYarnCacheCleanID validates rule identity.
+func TestIntegrationYarnCacheCleanID(t *testing.T) {
+	if NewYarnCacheClean().ID() != "DL3060" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationYarnCacheCleanMissing flags missing yarn cache clean.
+func TestIntegrationYarnCacheCleanMissing(t *testing.T) {
+	src := "FROM alpine\nRUN yarn install\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewYarnCacheClean()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationYarnCacheCleanOK ensures yarn cache clean suppresses findings.
+func TestIntegrationYarnCacheCleanOK(t *testing.T) {
+	src := "FROM alpine\nRUN yarn install && yarn cache clean\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewYarnCacheClean()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationYarnCacheCleanMount accepts cache mount usage.
+func TestIntegrationYarnCacheCleanMount(t *testing.T) {
+	src := "FROM alpine\nRUN --mount=type=cache,target=/root/.cache yarn install\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewYarnCacheClean()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationYarnCacheCleanNil ensures graceful handling of nil input.
+func TestIntegrationYarnCacheCleanNil(t *testing.T) {
+	r := NewYarnCacheClean()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}


### PR DESCRIPTION
## Summary
- implement DL3060 to require `yarn cache clean` after `yarn install` unless using a cache mount
- document DL3060 and list it in the rules README
- rename npm rule helpers to avoid name collisions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689eafc3a8248332af68c196c67c0f80