### PR TITLE
Add DL3030-DL3038 rules

### DIFF
--- a/docs/rules/DL3030.md
+++ b/docs/rules/DL3030.md
@@ -1,0 +1,3 @@
+# DL3030 - Use -y with yum install
+
+Ensure `yum install` commands include the `-y` or `--assumeyes` option to avoid interactive prompts.

--- a/docs/rules/DL3032.md
+++ b/docs/rules/DL3032.md
@@ -1,0 +1,3 @@
+# DL3032 - Run `yum clean all`
+
+After using `yum install`, clear the cache with `yum clean all` or remove `/var/cache/yum/*` in the same layer.

--- a/docs/rules/DL3033.md
+++ b/docs/rules/DL3033.md
@@ -1,0 +1,3 @@
+# DL3033 - Pin versions in yum install
+
+When using `yum install` or `yum module install`, specify package versions to ensure repeatable builds.

--- a/docs/rules/DL3034.md
+++ b/docs/rules/DL3034.md
@@ -1,0 +1,3 @@
+# DL3034 - Use non-interactive zypper
+
+Include `-y`, `-n`, `--no-confirm`, or `--non-interactive` with `zypper` to avoid interactive prompts during builds.

--- a/docs/rules/DL3035.md
+++ b/docs/rules/DL3035.md
@@ -1,0 +1,3 @@
+# DL3035 - Avoid `zypper dist-upgrade`
+
+Using `zypper dist-upgrade` or `zypper dup` is discouraged in Dockerfiles because it upgrades the base image unpredictably.

--- a/docs/rules/DL3036.md
+++ b/docs/rules/DL3036.md
@@ -1,0 +1,3 @@
+# DL3036 - Clean zypper cache
+
+After running `zypper install`, clear the package cache with `zypper clean` or `zypper cc` in the same layer.

--- a/docs/rules/DL3037.md
+++ b/docs/rules/DL3037.md
@@ -1,0 +1,3 @@
+# DL3037 - Pin versions in zypper install
+
+Specify explicit versions when installing packages with `zypper` to ensure deterministic builds.

--- a/docs/rules/DL3038.md
+++ b/docs/rules/DL3038.md
@@ -1,0 +1,3 @@
+# DL3038 - Use -y with dnf install
+
+Ensure `dnf` or `microdnf` install commands include the `-y` or `--assumeyes` flag to avoid interactive prompts.

--- a/internal/rules/DL3009.go
+++ b/internal/rules/DL3009.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/asymmetric-effort/docker-lint/internal/engine"
 	"github.com/asymmetric-effort/docker-lint/internal/ir"
-	"github.com/google/shlex"
-	"github.com/moby/buildkit/frontend/dockerfile/parser"
 )
 
 // aptListsCleanup ensures apt installs remove package lists in the same layer.
@@ -44,46 +42,6 @@ func (aptListsCleanup) Check(ctx context.Context, d *ir.Document) ([]engine.Find
 		}
 	}
 	return findings, nil
-}
-
-// splitRunSegments splits a RUN instruction into command segments separated by shell connectors.
-func splitRunSegments(n *parser.Node) [][]string {
-	if n == nil || n.Next == nil {
-		return nil
-	}
-	if n.Attributes != nil && n.Attributes["json"] {
-		return [][]string{{strings.ToLower(n.Next.Value)}}
-	}
-	tokens, err := shlex.Split(n.Next.Value)
-	if err != nil {
-		return nil
-	}
-	var segs [][]string
-	var cur []string
-	for _, tok := range tokens {
-		switch tok {
-		case "&&", "||", ";", "|":
-			if len(cur) > 0 {
-				segs = append(segs, lowerSlice(cur))
-				cur = nil
-			}
-		default:
-			cur = append(cur, tok)
-		}
-	}
-	if len(cur) > 0 {
-		segs = append(segs, lowerSlice(cur))
-	}
-	return segs
-}
-
-// lowerSlice returns a new slice with all elements lowercased.
-func lowerSlice(in []string) []string {
-	out := make([]string, len(in))
-	for i, s := range in {
-		out[i] = strings.ToLower(s)
-	}
-	return out
 }
 
 // needsAptListsCleanup reports whether an apt install occurred without subsequent cleanup.

--- a/internal/rules/DL3013.go
+++ b/internal/rules/DL3013.go
@@ -120,7 +120,7 @@ func violatesPipPin(cmd []string) bool {
 		return false
 	}
 	for _, p := range pkgs {
-		if !versionFixed(p) {
+		if !pipVersionFixed(p) {
 			return true
 		}
 	}
@@ -143,8 +143,8 @@ func isPip(tok string) bool {
 	return strings.HasPrefix(tok, "pip")
 }
 
-// versionFixed reports whether a package token pins its version.
-func versionFixed(pkg string) bool {
+// pipVersionFixed reports whether a package token pins its version.
+func pipVersionFixed(pkg string) bool {
 	if strings.Contains(pkg, "@") {
 		return true
 	}

--- a/internal/rules/DL3030.go
+++ b/internal/rules/DL3030.go
@@ -1,0 +1,69 @@
+// file: internal/rules/DL3030.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+
+package rules
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// requireYumYes enforces non-interactive yum commands.
+type requireYumYes struct{}
+
+// NewRequireYumYes constructs the rule.
+func NewRequireYumYes() engine.Rule { return requireYumYes{} }
+
+// ID returns the rule identifier.
+func (requireYumYes) ID() string { return "DL3030" }
+
+// Check inspects RUN instructions for yum install without -y.
+func (requireYumYes) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		segments := splitRunSegments(n)
+		for _, seg := range segments {
+			if isYumInstall(seg) && !hasYumYes(seg) {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL3030",
+					Message: "Use the -y switch to avoid manual input `yum install -y <package>`",
+					Line:    n.StartLine,
+				})
+				break
+			}
+		}
+	}
+	return findings, nil
+}
+
+// isYumInstall reports whether the segment invokes yum install variants.
+func isYumInstall(seg []string) bool {
+	if len(seg) < 2 || seg[0] != "yum" {
+		return false
+	}
+	for _, t := range seg[1:] {
+		if t == "install" || t == "groupinstall" || t == "localinstall" {
+			return true
+		}
+	}
+	return false
+}
+
+// hasYumYes reports if non-interactive flags are present.
+func hasYumYes(seg []string) bool {
+	for _, t := range seg {
+		if t == "-y" || t == "--assumeyes" || strings.HasPrefix(t, "--assumeyes=") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rules/DL3030_test.go
+++ b/internal/rules/DL3030_test.go
@@ -1,0 +1,74 @@
+// file: internal/rules/DL3030_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationRequireYumYesID validates rule identity.
+func TestIntegrationRequireYumYesID(t *testing.T) {
+	if NewRequireYumYes().ID() != "DL3030" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationRequireYumYesViolation detects missing -y.
+func TestIntegrationRequireYumYesViolation(t *testing.T) {
+	src := "FROM alpine\nRUN yum install wget\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewRequireYumYes()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationRequireYumYesClean ensures compliant commands pass.
+func TestIntegrationRequireYumYesClean(t *testing.T) {
+	src := "FROM alpine\nRUN yum install -y wget\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewRequireYumYes()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationRequireYumYesNil ensures graceful nil handling.
+func TestIntegrationRequireYumYesNil(t *testing.T) {
+	r := NewRequireYumYes()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/DL3032.go
+++ b/internal/rules/DL3032.go
@@ -1,0 +1,69 @@
+// file: internal/rules/DL3032.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+
+package rules
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// requireYumClean enforces cache cleanup after yum use.
+type requireYumClean struct{}
+
+// NewRequireYumClean constructs the rule.
+func NewRequireYumClean() engine.Rule { return requireYumClean{} }
+
+// ID returns the rule identifier.
+func (requireYumClean) ID() string { return "DL3032" }
+
+// Check ensures yum installs are followed by cleanup.
+func (requireYumClean) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		segments := splitRunSegments(n)
+		if yumCleanMissing(segments) {
+			findings = append(findings, engine.Finding{
+				RuleID:  "DL3032",
+				Message: "`yum clean all` missing after yum command.",
+				Line:    n.StartLine,
+			})
+		}
+	}
+	return findings, nil
+}
+
+// yumCleanMissing reports whether a yum install occurred without cleanup.
+func yumCleanMissing(segs [][]string) bool {
+	install := false
+	clean := false
+	for _, seg := range segs {
+		if isYumInstall(seg) {
+			install = true
+		}
+		if isYumClean(seg) {
+			clean = true
+		}
+	}
+	return install && !clean
+}
+
+// isYumClean detects yum clean or cache removal.
+func isYumClean(seg []string) bool {
+	if len(seg) >= 3 && seg[0] == "yum" && seg[1] == "clean" && seg[2] == "all" {
+		return true
+	}
+	if len(seg) >= 3 && seg[0] == "rm" && seg[1] == "-rf" && seg[2] == "/var/cache/yum/*" {
+		return true
+	}
+	return false
+}

--- a/internal/rules/DL3032_test.go
+++ b/internal/rules/DL3032_test.go
@@ -1,0 +1,74 @@
+// file: internal/rules/DL3032_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationRequireYumCleanID validates rule identity.
+func TestIntegrationRequireYumCleanID(t *testing.T) {
+	if NewRequireYumClean().ID() != "DL3032" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationRequireYumCleanViolation detects missing cleanup.
+func TestIntegrationRequireYumCleanViolation(t *testing.T) {
+	src := "FROM alpine\nRUN yum install wget\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewRequireYumClean()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationRequireYumCleanClean ensures compliant command passes.
+func TestIntegrationRequireYumCleanClean(t *testing.T) {
+	src := "FROM alpine\nRUN yum install wget && yum clean all\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewRequireYumClean()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationRequireYumCleanNil ensures graceful nil handling.
+func TestIntegrationRequireYumCleanNil(t *testing.T) {
+	r := NewRequireYumClean()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/DL3033.go
+++ b/internal/rules/DL3033.go
@@ -1,0 +1,100 @@
+// file: internal/rules/DL3033.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+
+package rules
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// pinYumVersions enforces version pinning in yum installs.
+type pinYumVersions struct{}
+
+// NewPinYumVersions constructs the rule.
+func NewPinYumVersions() engine.Rule { return pinYumVersions{} }
+
+// ID returns the rule identifier.
+func (pinYumVersions) ID() string { return "DL3033" }
+
+// Check scans RUN instructions for unpinned yum packages.
+func (pinYumVersions) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		segments := splitRunSegments(n)
+		for _, seg := range segments {
+			if len(seg) < 2 || seg[0] != "yum" {
+				continue
+			}
+			if violatesYumPin(seg) {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL3033",
+					Message: "Specify version with `yum install -y <package>-<version>`.",
+					Line:    n.StartLine,
+				})
+				break
+			}
+		}
+	}
+	return findings, nil
+}
+
+// violatesYumPin reports if yum packages or modules lack versions.
+func violatesYumPin(seg []string) bool {
+	if seg[1] == "module" {
+		idx := indexOf(seg, "install")
+		if idx == -1 {
+			return false
+		}
+		pkgs := collectNonFlag(seg[idx+1:])
+		for _, p := range pkgs {
+			if !strings.Contains(p, ":") {
+				return true
+			}
+		}
+		return false
+	}
+	// regular install
+	idx := indexOf(seg, "install")
+	if idx == -1 {
+		return false
+	}
+	pkgs := collectNonFlag(seg[idx+1:])
+	for _, p := range pkgs {
+		if !strings.Contains(p, "-") && !strings.HasSuffix(p, ".rpm") {
+			return true
+		}
+	}
+	return false
+}
+
+// indexOf returns index of token or -1.
+func indexOf(slice []string, target string) int {
+	for i, t := range slice {
+		if t == target {
+			return i
+		}
+	}
+	return -1
+}
+
+// collectNonFlag gathers non-flag arguments from token list.
+func collectNonFlag(tokens []string) []string {
+	var out []string
+	for _, t := range tokens {
+		if strings.HasPrefix(t, "-") {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}

--- a/internal/rules/DL3033_test.go
+++ b/internal/rules/DL3033_test.go
@@ -1,0 +1,95 @@
+// file: internal/rules/DL3033_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationPinYumVersionsID validates rule identity.
+func TestIntegrationPinYumVersionsID(t *testing.T) {
+	if NewPinYumVersions().ID() != "DL3033" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationPinYumVersionsViolation detects unpinned packages.
+func TestIntegrationPinYumVersionsViolation(t *testing.T) {
+	src := "FROM alpine\nRUN yum install pkg\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewPinYumVersions()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationPinYumVersionsClean ensures versioned packages pass.
+func TestIntegrationPinYumVersionsClean(t *testing.T) {
+	src := "FROM alpine\nRUN yum install pkg-1.0\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewPinYumVersions()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationPinYumVersionsModule ensures modules require version.
+func TestIntegrationPinYumVersionsModule(t *testing.T) {
+	src := "FROM alpine\nRUN yum module install nodejs\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewPinYumVersions()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationPinYumVersionsNil ensures graceful handling of nil input.
+func TestIntegrationPinYumVersionsNil(t *testing.T) {
+	r := NewPinYumVersions()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/DL3034.go
+++ b/internal/rules/DL3034.go
@@ -1,0 +1,70 @@
+// file: internal/rules/DL3034.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+
+package rules
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// requireZypperYes enforces non-interactive zypper commands.
+type requireZypperYes struct{}
+
+// NewRequireZypperYes constructs the rule.
+func NewRequireZypperYes() engine.Rule { return requireZypperYes{} }
+
+// ID returns the rule identifier.
+func (requireZypperYes) ID() string { return "DL3034" }
+
+// Check verifies zypper commands include a non-interactive switch.
+func (requireZypperYes) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		segments := splitRunSegments(n)
+		for _, seg := range segments {
+			if isZypperAction(seg) && !hasZypperYes(seg) {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL3034",
+					Message: "Non-interactive switch missing from `zypper` command: `zypper install -y`",
+					Line:    n.StartLine,
+				})
+				break
+			}
+		}
+	}
+	return findings, nil
+}
+
+// isZypperAction reports if command is zypper install/remove/etc.
+func isZypperAction(seg []string) bool {
+	if len(seg) < 2 || seg[0] != "zypper" {
+		return false
+	}
+	actions := []string{"install", "in", "remove", "rm", "source-install", "si", "patch"}
+	for _, a := range actions {
+		if seg[1] == a {
+			return true
+		}
+	}
+	return false
+}
+
+// hasZypperYes detects non-interactive flags.
+func hasZypperYes(seg []string) bool {
+	for _, t := range seg {
+		if t == "-y" || t == "-n" || t == "--non-interactive" || t == "--no-confirm" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rules/DL3034_test.go
+++ b/internal/rules/DL3034_test.go
@@ -1,0 +1,74 @@
+// file: internal/rules/DL3034_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationRequireZypperYesID validates rule identity.
+func TestIntegrationRequireZypperYesID(t *testing.T) {
+	if NewRequireZypperYes().ID() != "DL3034" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationRequireZypperYesViolation detects missing flags.
+func TestIntegrationRequireZypperYesViolation(t *testing.T) {
+	src := "FROM alpine\nRUN zypper install pkg\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewRequireZypperYes()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationRequireZypperYesClean ensures non-interactive flag passes.
+func TestIntegrationRequireZypperYesClean(t *testing.T) {
+	src := "FROM alpine\nRUN zypper install -y pkg\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewRequireZypperYes()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationRequireZypperYesNil ensures graceful nil handling.
+func TestIntegrationRequireZypperYesNil(t *testing.T) {
+	r := NewRequireZypperYes()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/DL3035.go
+++ b/internal/rules/DL3035.go
@@ -1,0 +1,57 @@
+// file: internal/rules/DL3035.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+
+package rules
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// forbidZypperDistUpgrade prohibits zypper dist-upgrade usage.
+type forbidZypperDistUpgrade struct{}
+
+// NewForbidZypperDistUpgrade constructs the rule.
+func NewForbidZypperDistUpgrade() engine.Rule { return forbidZypperDistUpgrade{} }
+
+// ID returns the rule identifier.
+func (forbidZypperDistUpgrade) ID() string { return "DL3035" }
+
+// Check flags zypper dist-upgrade commands.
+func (forbidZypperDistUpgrade) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		segments := splitRunSegments(n)
+		for _, seg := range segments {
+			if isZypperDistUpgrade(seg) {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL3035",
+					Message: "Do not use `zypper dist-upgrade`.",
+					Line:    n.StartLine,
+				})
+				break
+			}
+		}
+	}
+	return findings, nil
+}
+
+// isZypperDistUpgrade reports if segment runs zypper dist-upgrade/dup.
+func isZypperDistUpgrade(seg []string) bool {
+	if len(seg) < 2 || seg[0] != "zypper" {
+		return false
+	}
+	if seg[1] == "dist-upgrade" || seg[1] == "dup" {
+		return true
+	}
+	return false
+}

--- a/internal/rules/DL3035_test.go
+++ b/internal/rules/DL3035_test.go
@@ -1,0 +1,74 @@
+// file: internal/rules/DL3035_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationForbidZypperDistUpgradeID validates rule identity.
+func TestIntegrationForbidZypperDistUpgradeID(t *testing.T) {
+	if NewForbidZypperDistUpgrade().ID() != "DL3035" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationForbidZypperDistUpgradeViolation detects disallowed command.
+func TestIntegrationForbidZypperDistUpgradeViolation(t *testing.T) {
+	src := "FROM alpine\nRUN zypper dist-upgrade\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewForbidZypperDistUpgrade()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationForbidZypperDistUpgradeClean ensures other commands pass.
+func TestIntegrationForbidZypperDistUpgradeClean(t *testing.T) {
+	src := "FROM alpine\nRUN zypper install -y pkg\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewForbidZypperDistUpgrade()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationForbidZypperDistUpgradeNil ensures graceful nil handling.
+func TestIntegrationForbidZypperDistUpgradeNil(t *testing.T) {
+	r := NewForbidZypperDistUpgrade()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/DL3036.go
+++ b/internal/rules/DL3036.go
@@ -1,0 +1,77 @@
+// file: internal/rules/DL3036.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+
+package rules
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// requireZypperClean enforces cache cleanup after zypper use.
+type requireZypperClean struct{}
+
+// NewRequireZypperClean constructs the rule.
+func NewRequireZypperClean() engine.Rule { return requireZypperClean{} }
+
+// ID returns the rule identifier.
+func (requireZypperClean) ID() string { return "DL3036" }
+
+// Check ensures zypper installs are followed by cleanup.
+func (requireZypperClean) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		segments := splitRunSegments(n)
+		if zypperCleanMissing(segments) {
+			findings = append(findings, engine.Finding{
+				RuleID:  "DL3036",
+				Message: "`zypper clean` missing after zypper use.",
+				Line:    n.StartLine,
+			})
+		}
+	}
+	return findings, nil
+}
+
+// zypperCleanMissing reports if install without cleanup occurs.
+func zypperCleanMissing(segs [][]string) bool {
+	install := false
+	clean := false
+	for _, seg := range segs {
+		if isZypperInstall(seg) {
+			install = true
+		}
+		if isZypperClean(seg) {
+			clean = true
+		}
+	}
+	return install && !clean
+}
+
+// isZypperInstall detects zypper install/in.
+func isZypperInstall(seg []string) bool {
+	if len(seg) < 2 || seg[0] != "zypper" {
+		return false
+	}
+	if seg[1] == "install" || seg[1] == "in" {
+		return true
+	}
+	return false
+}
+
+// isZypperClean detects zypper clean/cc.
+func isZypperClean(seg []string) bool {
+	if len(seg) >= 2 && seg[0] == "zypper" && (seg[1] == "clean" || seg[1] == "cc") {
+		return true
+	}
+	return false
+}

--- a/internal/rules/DL3036_test.go
+++ b/internal/rules/DL3036_test.go
@@ -1,0 +1,74 @@
+// file: internal/rules/DL3036_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationRequireZypperCleanID validates rule identity.
+func TestIntegrationRequireZypperCleanID(t *testing.T) {
+	if NewRequireZypperClean().ID() != "DL3036" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationRequireZypperCleanViolation detects missing cleanup.
+func TestIntegrationRequireZypperCleanViolation(t *testing.T) {
+	src := "FROM alpine\nRUN zypper install pkg\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewRequireZypperClean()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationRequireZypperCleanClean ensures cleanup passes.
+func TestIntegrationRequireZypperCleanClean(t *testing.T) {
+	src := "FROM alpine\nRUN zypper in pkg && zypper clean\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewRequireZypperClean()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationRequireZypperCleanNil ensures graceful nil handling.
+func TestIntegrationRequireZypperCleanNil(t *testing.T) {
+	r := NewRequireZypperClean()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/DL3037.go
+++ b/internal/rules/DL3037.go
@@ -1,0 +1,59 @@
+// file: internal/rules/DL3037.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+
+package rules
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// pinZypperVersions enforces version pinning for zypper installs.
+type pinZypperVersions struct{}
+
+// NewPinZypperVersions constructs the rule.
+func NewPinZypperVersions() engine.Rule { return pinZypperVersions{} }
+
+// ID returns the rule identifier.
+func (pinZypperVersions) ID() string { return "DL3037" }
+
+// Check scans RUN instructions for unpinned zypper packages.
+func (pinZypperVersions) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		segments := splitRunSegments(n)
+		for _, seg := range segments {
+			if isZypperInstall(seg) {
+				pkgs := collectNonFlag(seg[2:])
+				if len(pkgs) > 0 && !allZypperVersionFixed(pkgs) {
+					findings = append(findings, engine.Finding{
+						RuleID:  "DL3037",
+						Message: "Specify version with `zypper install -y <package>=<version>`.",
+						Line:    n.StartLine,
+					})
+					break
+				}
+			}
+		}
+	}
+	return findings, nil
+}
+
+// allZypperVersionFixed returns true if each package pins a version.
+func allZypperVersionFixed(pkgs []string) bool {
+	for _, p := range pkgs {
+		if !(strings.Contains(p, "=") || strings.Contains(p, ">=") || strings.Contains(p, ">") || strings.Contains(p, "<=") || strings.Contains(p, "<") || strings.HasSuffix(p, ".rpm")) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/rules/DL3037_test.go
+++ b/internal/rules/DL3037_test.go
@@ -1,0 +1,74 @@
+// file: internal/rules/DL3037_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationPinZypperVersionsID validates rule identity.
+func TestIntegrationPinZypperVersionsID(t *testing.T) {
+	if NewPinZypperVersions().ID() != "DL3037" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationPinZypperVersionsViolation detects unpinned packages.
+func TestIntegrationPinZypperVersionsViolation(t *testing.T) {
+	src := "FROM alpine\nRUN zypper install pkg\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewPinZypperVersions()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationPinZypperVersionsClean ensures versioned packages pass.
+func TestIntegrationPinZypperVersionsClean(t *testing.T) {
+	src := "FROM alpine\nRUN zypper install pkg=1.0\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewPinZypperVersions()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationPinZypperVersionsNil ensures graceful nil handling.
+func TestIntegrationPinZypperVersionsNil(t *testing.T) {
+	r := NewPinZypperVersions()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/DL3038.go
+++ b/internal/rules/DL3038.go
@@ -1,0 +1,72 @@
+// file: internal/rules/DL3038.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+
+package rules
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// requireDnfYes enforces non-interactive dnf commands.
+type requireDnfYes struct{}
+
+// NewRequireDnfYes constructs the rule.
+func NewRequireDnfYes() engine.Rule { return requireDnfYes{} }
+
+// ID returns the rule identifier.
+func (requireDnfYes) ID() string { return "DL3038" }
+
+// Check inspects RUN instructions for dnf installs without -y.
+func (requireDnfYes) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		segments := splitRunSegments(n)
+		for _, seg := range segments {
+			if isDnfInstall(seg) && !hasDnfYes(seg) {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL3038",
+					Message: "Use the -y switch to avoid manual input `dnf install -y <package>`",
+					Line:    n.StartLine,
+				})
+				break
+			}
+		}
+	}
+	return findings, nil
+}
+
+// isDnfInstall reports whether segment invokes dnf/microdnf install.
+func isDnfInstall(seg []string) bool {
+	if len(seg) < 2 {
+		return false
+	}
+	if seg[0] != "dnf" && seg[0] != "microdnf" {
+		return false
+	}
+	for _, t := range seg[1:] {
+		if t == "install" || t == "groupinstall" || t == "localinstall" {
+			return true
+		}
+	}
+	return false
+}
+
+// hasDnfYes detects non-interactive flags.
+func hasDnfYes(seg []string) bool {
+	for _, t := range seg {
+		if t == "-y" || t == "--assumeyes" || strings.HasPrefix(t, "--assumeyes=") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rules/DL3038_test.go
+++ b/internal/rules/DL3038_test.go
@@ -1,0 +1,74 @@
+// file: internal/rules/DL3038_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationRequireDnfYesID validates rule identity.
+func TestIntegrationRequireDnfYesID(t *testing.T) {
+	if NewRequireDnfYes().ID() != "DL3038" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationRequireDnfYesViolation detects missing -y.
+func TestIntegrationRequireDnfYesViolation(t *testing.T) {
+	src := "FROM alpine\nRUN dnf install wget\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewRequireDnfYes()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationRequireDnfYesClean ensures compliant commands pass.
+func TestIntegrationRequireDnfYesClean(t *testing.T) {
+	src := "FROM alpine\nRUN dnf install -y wget\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewRequireDnfYes()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationRequireDnfYesNil ensures graceful nil handling.
+func TestIntegrationRequireDnfYesNil(t *testing.T) {
+	r := NewRequireDnfYes()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/ruleutil.go
+++ b/internal/rules/ruleutil.go
@@ -1,0 +1,50 @@
+// file: internal/rules/ruleutil.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+
+package rules
+
+import (
+	"github.com/google/shlex"
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+	"strings"
+)
+
+// splitRunSegments splits a RUN instruction into command segments separated by shell connectors.
+func splitRunSegments(n *parser.Node) [][]string {
+	if n == nil || n.Next == nil {
+		return nil
+	}
+	if n.Attributes != nil && n.Attributes["json"] {
+		return [][]string{{strings.ToLower(n.Next.Value)}}
+	}
+	tokens, err := shlex.Split(n.Next.Value)
+	if err != nil {
+		return nil
+	}
+	var segs [][]string
+	var cur []string
+	for _, tok := range tokens {
+		switch tok {
+		case "&&", "||", ";", "|":
+			if len(cur) > 0 {
+				segs = append(segs, lowerSlice(cur))
+				cur = nil
+			}
+		default:
+			cur = append(cur, tok)
+		}
+	}
+	if len(cur) > 0 {
+		segs = append(segs, lowerSlice(cur))
+	}
+	return segs
+}
+
+// lowerSlice returns a new slice with all elements lowercased.
+func lowerSlice(in []string) []string {
+	out := make([]string, len(in))
+	for i, s := range in {
+		out[i] = strings.ToLower(s)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- centralize splitRunSegments utility to remove duplication
- implement hadolint rules DL3030, DL3032-3038 with tests and docs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689eaeee2f448332ae1609438e24457c