### PR TITLE
feat: add DL3050-DL3059 rules

### DIFF
--- a/docs/rules/DL3050.md
+++ b/docs/rules/DL3050.md
@@ -1,0 +1,3 @@
+# DL3050 - Superfluous labels present
+
+When strict label checking is enabled, every `LABEL` key must be defined in the schema.

--- a/docs/rules/DL3051.md
+++ b/docs/rules/DL3051.md
@@ -1,0 +1,3 @@
+# DL3051 - Label value is empty
+
+Labels defined in the schema must have a non-empty value.

--- a/docs/rules/DL3052.md
+++ b/docs/rules/DL3052.md
@@ -1,0 +1,3 @@
+# DL3052 - Label is not a valid URL
+
+Labels expected to contain URLs must use valid URL syntax with scheme and host.

--- a/docs/rules/DL3053.md
+++ b/docs/rules/DL3053.md
@@ -1,0 +1,3 @@
+# DL3053 - Label does not conform to RFC3339
+
+Labels designated as timestamps must be formatted according to RFC3339.

--- a/docs/rules/DL3054.md
+++ b/docs/rules/DL3054.md
@@ -1,0 +1,3 @@
+# DL3054 - Label is not a valid SPDX identifier
+
+License labels must match the SPDX identifier pattern.

--- a/docs/rules/DL3055.md
+++ b/docs/rules/DL3055.md
@@ -1,0 +1,3 @@
+# DL3055 - Label is not a valid git hash
+
+Labels storing git revisions must be 7 or 40 hexadecimal characters.

--- a/docs/rules/DL3056.md
+++ b/docs/rules/DL3056.md
@@ -1,0 +1,3 @@
+# DL3056 - Label does not conform to semantic versioning
+
+Labels representing versions must follow the semantic versioning specification.

--- a/docs/rules/DL3057.md
+++ b/docs/rules/DL3057.md
@@ -1,0 +1,3 @@
+# DL3057 - `HEALTHCHECK` instruction missing
+
+Every build stage should define a `HEALTHCHECK` or inherit from a stage that does.

--- a/docs/rules/DL3058.md
+++ b/docs/rules/DL3058.md
@@ -1,0 +1,3 @@
+# DL3058 - Label is not a valid email address
+
+Labels defined as email addresses must conform to RFC5322 formatting.

--- a/docs/rules/DL3059.md
+++ b/docs/rules/DL3059.md
@@ -1,0 +1,3 @@
+# DL3059 - Multiple consecutive `RUN` instructions
+
+Use a single `RUN` with command chaining instead of many simple consecutive `RUN` layers.

--- a/internal/rules/DL3050.go
+++ b/internal/rules/DL3050.go
@@ -1,0 +1,48 @@
+package rules
+
+/*
+ * file: internal/rules/DL3050.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// superfluousLabels checks for labels not defined in the schema when strict mode is enabled.
+type superfluousLabels struct {
+	schema LabelSchema
+	strict bool
+}
+
+// NewSuperfluousLabels constructs the rule.
+func NewSuperfluousLabels(schema LabelSchema, strict bool) engine.Rule {
+	return &superfluousLabels{schema: schema, strict: strict}
+}
+
+// ID returns the rule identifier.
+func (superfluousLabels) ID() string { return "DL3050" }
+
+// Check reports labels not present in the schema when strict mode is enabled.
+func (r *superfluousLabels) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if !r.strict || d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "label") {
+			continue
+		}
+		for _, p := range collectLabelPairs(n) {
+			if !inSchema(r.schema, p.Key) {
+				findings = append(findings, engine.Finding{RuleID: "DL3050", Message: "Superfluous label(s) present.", Line: n.StartLine})
+				break
+			}
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/DL3050_test.go
+++ b/internal/rules/DL3050_test.go
@@ -1,0 +1,88 @@
+// file: internal/rules/DL3050_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+func TestSuperfluousLabelsID(t *testing.T) {
+	if NewSuperfluousLabels(nil, true).ID() != "DL3050" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+func TestSuperfluousLabelsViolation(t *testing.T) {
+	src := "FROM scratch\nLABEL unknown=1\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	schema := LabelSchema{"known": LabelTypeString}
+	r := NewSuperfluousLabels(schema, true)
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+func TestSuperfluousLabelsClean(t *testing.T) {
+	src := "FROM scratch\nLABEL known=1\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	schema := LabelSchema{"known": LabelTypeString}
+	r := NewSuperfluousLabels(schema, true)
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+func TestSuperfluousLabelsNonStrict(t *testing.T) {
+	src := "FROM scratch\nLABEL unknown=1\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewSuperfluousLabels(nil, false)
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+func TestSuperfluousLabelsNilDocument(t *testing.T) {
+	r := NewSuperfluousLabels(nil, true)
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/DL3051.go
+++ b/internal/rules/DL3051.go
@@ -1,0 +1,42 @@
+package rules
+
+/*
+ * file: internal/rules/DL3051.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// labelNotEmpty ensures specific labels are not empty.
+type labelNotEmpty struct{ schema LabelSchema }
+
+// NewLabelNotEmpty constructs the rule.
+func NewLabelNotEmpty(schema LabelSchema) engine.Rule { return &labelNotEmpty{schema: schema} }
+
+// ID returns the rule identifier.
+func (labelNotEmpty) ID() string { return "DL3051" }
+
+// Check reports schema-defined labels that have empty values.
+func (r *labelNotEmpty) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "label") {
+			continue
+		}
+		for _, p := range collectLabelPairs(n) {
+			if inSchema(r.schema, p.Key) && p.Value == "" {
+				findings = append(findings, engine.Finding{RuleID: "DL3051", Message: "label `" + p.Key + "` is empty.", Line: n.StartLine})
+			}
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/DL3051_test.go
+++ b/internal/rules/DL3051_test.go
@@ -1,0 +1,68 @@
+// file: internal/rules/DL3051_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+func TestLabelNotEmptyID(t *testing.T) {
+	if NewLabelNotEmpty(nil).ID() != "DL3051" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+func TestLabelNotEmptyViolation(t *testing.T) {
+	src := "FROM scratch\nLABEL foo=\"\"\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	schema := LabelSchema{"foo": LabelTypeString}
+	r := NewLabelNotEmpty(schema)
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+func TestLabelNotEmptyClean(t *testing.T) {
+	src := "FROM scratch\nLABEL foo=bar\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	schema := LabelSchema{"foo": LabelTypeString}
+	r := NewLabelNotEmpty(schema)
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+func TestLabelNotEmptyNilDocument(t *testing.T) {
+	r := NewLabelNotEmpty(nil)
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/DL3052.go
+++ b/internal/rules/DL3052.go
@@ -1,0 +1,46 @@
+package rules
+
+/*
+ * file: internal/rules/DL3052.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"net/url"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// labelURLValid ensures URL-typed labels contain valid URLs.
+type labelURLValid struct{ schema LabelSchema }
+
+// NewLabelURLValid constructs the rule.
+func NewLabelURLValid(schema LabelSchema) engine.Rule { return &labelURLValid{schema: schema} }
+
+// ID returns the rule identifier.
+func (labelURLValid) ID() string { return "DL3052" }
+
+// Check validates URL labels against RFC 3986.
+func (r *labelURLValid) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "label") {
+			continue
+		}
+		for _, p := range collectLabelPairs(n) {
+			if r.schema[p.Key] == LabelTypeURL {
+				u, err := url.Parse(p.Value)
+				if err != nil || u.Scheme == "" || u.Host == "" {
+					findings = append(findings, engine.Finding{RuleID: "DL3052", Message: "Label `" + p.Key + "` is not a valid URL.", Line: n.StartLine})
+				}
+			}
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/DL3052_test.go
+++ b/internal/rules/DL3052_test.go
@@ -1,0 +1,68 @@
+// file: internal/rules/DL3052_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+func TestLabelURLValidID(t *testing.T) {
+	if NewLabelURLValid(nil).ID() != "DL3052" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+func TestLabelURLValidViolation(t *testing.T) {
+	src := "FROM scratch\nLABEL homepage=not-a-url\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	schema := LabelSchema{"homepage": LabelTypeURL}
+	r := NewLabelURLValid(schema)
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+func TestLabelURLValidClean(t *testing.T) {
+	src := "FROM scratch\nLABEL homepage=http://example.com\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	schema := LabelSchema{"homepage": LabelTypeURL}
+	r := NewLabelURLValid(schema)
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+func TestLabelURLValidNilDocument(t *testing.T) {
+	r := NewLabelURLValid(nil)
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/DL3053.go
+++ b/internal/rules/DL3053.go
@@ -1,0 +1,45 @@
+package rules
+
+/*
+ * file: internal/rules/DL3053.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// labelTimeRFC3339 ensures RFC3339-typed labels are valid timestamps.
+type labelTimeRFC3339 struct{ schema LabelSchema }
+
+// NewLabelTimeRFC3339 constructs the rule.
+func NewLabelTimeRFC3339(schema LabelSchema) engine.Rule { return &labelTimeRFC3339{schema: schema} }
+
+// ID returns the rule identifier.
+func (labelTimeRFC3339) ID() string { return "DL3053" }
+
+// Check validates time labels.
+func (r *labelTimeRFC3339) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "label") {
+			continue
+		}
+		for _, p := range collectLabelPairs(n) {
+			if r.schema[p.Key] == LabelTypeRFC3339 {
+				if _, err := time.Parse(time.RFC3339, p.Value); err != nil {
+					findings = append(findings, engine.Finding{RuleID: "DL3053", Message: "Label `" + p.Key + "` is not a valid time format - must conform to RFC3339.", Line: n.StartLine})
+				}
+			}
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/DL3053_test.go
+++ b/internal/rules/DL3053_test.go
@@ -1,0 +1,68 @@
+// file: internal/rules/DL3053_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+func TestLabelTimeRFC3339ID(t *testing.T) {
+	if NewLabelTimeRFC3339(nil).ID() != "DL3053" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+func TestLabelTimeRFC3339Violation(t *testing.T) {
+	src := "FROM scratch\nLABEL built=not-time\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	schema := LabelSchema{"built": LabelTypeRFC3339}
+	r := NewLabelTimeRFC3339(schema)
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+func TestLabelTimeRFC3339Clean(t *testing.T) {
+	src := "FROM scratch\nLABEL built=2025-01-01T00:00:00Z\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	schema := LabelSchema{"built": LabelTypeRFC3339}
+	r := NewLabelTimeRFC3339(schema)
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+func TestLabelTimeRFC3339NilDocument(t *testing.T) {
+	r := NewLabelTimeRFC3339(nil)
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/DL3054.go
+++ b/internal/rules/DL3054.go
@@ -1,0 +1,47 @@
+package rules
+
+/*
+ * file: internal/rules/DL3054.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+var spdxPattern = regexp.MustCompile(`^[A-Za-z0-9-.+]+$`)
+
+// labelSPDXValid ensures SPDX-typed labels match SPDX identifier pattern.
+type labelSPDXValid struct{ schema LabelSchema }
+
+// NewLabelSPDXValid constructs the rule.
+func NewLabelSPDXValid(schema LabelSchema) engine.Rule { return &labelSPDXValid{schema: schema} }
+
+// ID returns the rule identifier.
+func (labelSPDXValid) ID() string { return "DL3054" }
+
+// Check validates SPDX label values.
+func (r *labelSPDXValid) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "label") {
+			continue
+		}
+		for _, p := range collectLabelPairs(n) {
+			if r.schema[p.Key] == LabelTypeSPDX {
+				if !spdxPattern.MatchString(p.Value) {
+					findings = append(findings, engine.Finding{RuleID: "DL3054", Message: "Label `" + p.Key + "` is not a valid SPDX identifier.", Line: n.StartLine})
+				}
+			}
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/DL3054_test.go
+++ b/internal/rules/DL3054_test.go
@@ -1,0 +1,68 @@
+// file: internal/rules/DL3054_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+func TestLabelSPDXValidID(t *testing.T) {
+	if NewLabelSPDXValid(nil).ID() != "DL3054" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+func TestLabelSPDXValidViolation(t *testing.T) {
+	src := "FROM scratch\nLABEL license=not@spdx\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	schema := LabelSchema{"license": LabelTypeSPDX}
+	r := NewLabelSPDXValid(schema)
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+func TestLabelSPDXValidClean(t *testing.T) {
+	src := "FROM scratch\nLABEL license=MIT\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	schema := LabelSchema{"license": LabelTypeSPDX}
+	r := NewLabelSPDXValid(schema)
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+func TestLabelSPDXValidNilDocument(t *testing.T) {
+	r := NewLabelSPDXValid(nil)
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/DL3055.go
+++ b/internal/rules/DL3055.go
@@ -1,0 +1,47 @@
+package rules
+
+/*
+ * file: internal/rules/DL3055.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+var gitHashPattern = regexp.MustCompile(`^[0-9a-f]{7}([0-9a-f]{33})?$`)
+
+// labelGitHashValid ensures Git hash labels are valid.
+type labelGitHashValid struct{ schema LabelSchema }
+
+// NewLabelGitHashValid constructs the rule.
+func NewLabelGitHashValid(schema LabelSchema) engine.Rule { return &labelGitHashValid{schema: schema} }
+
+// ID returns the rule identifier.
+func (labelGitHashValid) ID() string { return "DL3055" }
+
+// Check validates Git hash label values.
+func (r *labelGitHashValid) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "label") {
+			continue
+		}
+		for _, p := range collectLabelPairs(n) {
+			if r.schema[p.Key] == LabelTypeGitHash {
+				if !gitHashPattern.MatchString(strings.ToLower(p.Value)) {
+					findings = append(findings, engine.Finding{RuleID: "DL3055", Message: "Label `" + p.Key + "` is not a valid git hash.", Line: n.StartLine})
+				}
+			}
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/DL3055_test.go
+++ b/internal/rules/DL3055_test.go
@@ -1,0 +1,68 @@
+// file: internal/rules/DL3055_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+func TestLabelGitHashValidID(t *testing.T) {
+	if NewLabelGitHashValid(nil).ID() != "DL3055" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+func TestLabelGitHashValidViolation(t *testing.T) {
+	src := "FROM scratch\nLABEL commit=xyz\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	schema := LabelSchema{"commit": LabelTypeGitHash}
+	r := NewLabelGitHashValid(schema)
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+func TestLabelGitHashValidClean(t *testing.T) {
+	src := "FROM scratch\nLABEL commit=0123456789abcdef0123456789abcdef01234567\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	schema := LabelSchema{"commit": LabelTypeGitHash}
+	r := NewLabelGitHashValid(schema)
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+func TestLabelGitHashValidNilDocument(t *testing.T) {
+	r := NewLabelGitHashValid(nil)
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/DL3056.go
+++ b/internal/rules/DL3056.go
@@ -1,0 +1,47 @@
+package rules
+
+/*
+ * file: internal/rules/DL3056.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+var semverPattern = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?$`)
+
+// labelSemVerValid ensures SemVer-typed labels conform to semantic versioning.
+type labelSemVerValid struct{ schema LabelSchema }
+
+// NewLabelSemVerValid constructs the rule.
+func NewLabelSemVerValid(schema LabelSchema) engine.Rule { return &labelSemVerValid{schema: schema} }
+
+// ID returns the rule identifier.
+func (labelSemVerValid) ID() string { return "DL3056" }
+
+// Check validates semantic version labels.
+func (r *labelSemVerValid) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "label") {
+			continue
+		}
+		for _, p := range collectLabelPairs(n) {
+			if r.schema[p.Key] == LabelTypeSemVer {
+				if !semverPattern.MatchString(p.Value) {
+					findings = append(findings, engine.Finding{RuleID: "DL3056", Message: "Label `" + p.Key + "` does not conform to semantic versioning.", Line: n.StartLine})
+				}
+			}
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/DL3056_test.go
+++ b/internal/rules/DL3056_test.go
@@ -1,0 +1,68 @@
+// file: internal/rules/DL3056_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+func TestLabelSemVerValidID(t *testing.T) {
+	if NewLabelSemVerValid(nil).ID() != "DL3056" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+func TestLabelSemVerValidViolation(t *testing.T) {
+	src := "FROM scratch\nLABEL version=1.0\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	schema := LabelSchema{"version": LabelTypeSemVer}
+	r := NewLabelSemVerValid(schema)
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+func TestLabelSemVerValidClean(t *testing.T) {
+	src := "FROM scratch\nLABEL version=1.2.3\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	schema := LabelSchema{"version": LabelTypeSemVer}
+	r := NewLabelSemVerValid(schema)
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+func TestLabelSemVerValidNilDocument(t *testing.T) {
+	r := NewLabelSemVerValid(nil)
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/DL3057.go
+++ b/internal/rules/DL3057.go
@@ -1,0 +1,96 @@
+package rules
+
+/*
+ * file: internal/rules/DL3057.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// healthcheckExists reports stages missing a HEALTHCHECK instruction.
+type healthcheckExists struct{}
+
+// NewHealthcheckExists constructs the rule.
+func NewHealthcheckExists() engine.Rule { return healthcheckExists{} }
+
+// ID returns the rule identifier.
+func (healthcheckExists) ID() string { return "DL3057" }
+
+// Check verifies that each stage or its base image defines a HEALTHCHECK.
+func (healthcheckExists) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	type stage struct {
+		line     int
+		parent   int
+		hasCheck bool
+	}
+	var stages []*stage
+	nameMap := make(map[string]int)
+	current := -1
+	for _, n := range d.AST.Children {
+		switch strings.ToLower(n.Value) {
+		case "from":
+			base := ""
+			alias := ""
+			if n.Next != nil {
+				base = n.Next.Value
+				for tok := n.Next.Next; tok != nil; tok = tok.Next {
+					if strings.EqualFold(tok.Value, "as") && tok.Next != nil {
+						alias = tok.Next.Value
+						break
+					}
+				}
+			}
+			parent := -1
+			if idx, ok := nameMap[base]; ok {
+				parent = idx
+			}
+			st := &stage{line: n.StartLine, parent: parent}
+			stages = append(stages, st)
+			name := alias
+			if name == "" {
+				name = base
+			}
+			nameMap[name] = len(stages) - 1
+			current = len(stages) - 1
+		case "healthcheck":
+			if current >= 0 {
+				stages[current].hasCheck = true
+			}
+		}
+	}
+	cache := make(map[int]bool)
+	var hasHC func(int) bool
+	hasHC = func(id int) bool {
+		if v, ok := cache[id]; ok {
+			return v
+		}
+		st := stages[id]
+		if st.hasCheck {
+			cache[id] = true
+			return true
+		}
+		if st.parent == -1 {
+			cache[id] = false
+			return false
+		}
+		v := hasHC(st.parent)
+		cache[id] = v
+		return v
+	}
+	for id, st := range stages {
+		if !hasHC(id) {
+			findings = append(findings, engine.Finding{RuleID: "DL3057", Message: "`HEALTHCHECK` instruction missing.", Line: st.line})
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/DL3057_test.go
+++ b/internal/rules/DL3057_test.go
@@ -1,0 +1,86 @@
+// file: internal/rules/DL3057_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+func TestHealthcheckExistsID(t *testing.T) {
+	if NewHealthcheckExists().ID() != "DL3057" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+func TestHealthcheckExistsViolation(t *testing.T) {
+	src := "FROM scratch\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewHealthcheckExists()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+func TestHealthcheckExistsClean(t *testing.T) {
+	src := "FROM scratch\nHEALTHCHECK CMD true\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewHealthcheckExists()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+func TestHealthcheckExistsInherited(t *testing.T) {
+	src := "FROM scratch AS base\nHEALTHCHECK CMD true\nFROM base\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewHealthcheckExists()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+func TestHealthcheckExistsNilDocument(t *testing.T) {
+	r := NewHealthcheckExists()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/DL3058.go
+++ b/internal/rules/DL3058.go
@@ -1,0 +1,45 @@
+package rules
+
+/*
+ * file: internal/rules/DL3058.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"net/mail"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// labelEmailValid ensures email-typed labels contain valid addresses.
+type labelEmailValid struct{ schema LabelSchema }
+
+// NewLabelEmailValid constructs the rule.
+func NewLabelEmailValid(schema LabelSchema) engine.Rule { return &labelEmailValid{schema: schema} }
+
+// ID returns the rule identifier.
+func (labelEmailValid) ID() string { return "DL3058" }
+
+// Check validates email label values.
+func (r *labelEmailValid) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "label") {
+			continue
+		}
+		for _, p := range collectLabelPairs(n) {
+			if r.schema[p.Key] == LabelTypeEmail {
+				if _, err := mail.ParseAddress(p.Value); err != nil {
+					findings = append(findings, engine.Finding{RuleID: "DL3058", Message: "Label `" + p.Key + "` is not a valid email format - must conform to RFC5322.", Line: n.StartLine})
+				}
+			}
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/DL3058_test.go
+++ b/internal/rules/DL3058_test.go
@@ -1,0 +1,68 @@
+// file: internal/rules/DL3058_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+func TestLabelEmailValidID(t *testing.T) {
+	if NewLabelEmailValid(nil).ID() != "DL3058" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+func TestLabelEmailValidViolation(t *testing.T) {
+	src := "FROM scratch\nLABEL maintainer=not-an-email\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	schema := LabelSchema{"maintainer": LabelTypeEmail}
+	r := NewLabelEmailValid(schema)
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+func TestLabelEmailValidClean(t *testing.T) {
+	src := "FROM scratch\nLABEL maintainer=test@example.com\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	schema := LabelSchema{"maintainer": LabelTypeEmail}
+	r := NewLabelEmailValid(schema)
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+func TestLabelEmailValidNilDocument(t *testing.T) {
+	r := NewLabelEmailValid(nil)
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/DL3059.go
+++ b/internal/rules/DL3059.go
@@ -1,0 +1,69 @@
+package rules
+
+/*
+ * file: internal/rules/DL3059.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+)
+
+// consecutiveRun detects multiple consecutive RUN instructions with few commands.
+type consecutiveRun struct {
+	prevFlags string
+	prevCount int
+	seen      bool
+}
+
+// NewConsecutiveRun constructs the rule.
+func NewConsecutiveRun() engine.Rule { return &consecutiveRun{} }
+
+// ID returns the rule identifier.
+func (consecutiveRun) ID() string { return "DL3059" }
+
+// Check flags consecutive simple RUN instructions for consolidation.
+func (r *consecutiveRun) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	reset := func() { r.seen = false }
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			if strings.EqualFold(n.Value, "#") {
+				continue
+			}
+			reset()
+			continue
+		}
+		count := countRunCommands(n)
+		flags := canonicalFlags(n.Flags)
+		if r.seen && r.prevFlags == flags && r.prevCount <= 2 && count <= 2 {
+			findings = append(findings, engine.Finding{RuleID: "DL3059", Message: "Multiple consecutive `RUN` instructions. Consider consolidation.", Line: n.StartLine})
+		}
+		r.prevFlags = flags
+		r.prevCount = count
+		r.seen = true
+	}
+	return findings, nil
+}
+
+// canonicalFlags normalizes run flags for comparison.
+func canonicalFlags(flags []string) string {
+	cp := append([]string(nil), flags...)
+	sort.Strings(cp)
+	return strings.Join(cp, " ")
+}
+
+// countRunCommands returns the number of commands in a RUN instruction.
+func countRunCommands(n *parser.Node) int {
+	segs := splitRunSegments(n)
+	return len(segs)
+}

--- a/internal/rules/DL3059_test.go
+++ b/internal/rules/DL3059_test.go
@@ -1,0 +1,66 @@
+// file: internal/rules/DL3059_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+func TestConsecutiveRunID(t *testing.T) {
+	if NewConsecutiveRun().ID() != "DL3059" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+func TestConsecutiveRunViolation(t *testing.T) {
+	src := "FROM scratch\nRUN echo a\nRUN echo b\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewConsecutiveRun()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+func TestConsecutiveRunClean(t *testing.T) {
+	src := "FROM scratch\nRUN echo a\nENV A=B\nRUN echo b\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewConsecutiveRun()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+func TestConsecutiveRunNilDocument(t *testing.T) {
+	r := NewConsecutiveRun()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+}

--- a/internal/rules/label_utils.go
+++ b/internal/rules/label_utils.go
@@ -1,0 +1,53 @@
+package rules
+
+/*
+ * file: internal/rules/label_utils.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+)
+
+// LabelType represents the expected format for a label value.
+type LabelType int
+
+const (
+	LabelTypeString LabelType = iota
+	LabelTypeURL
+	LabelTypeRFC3339
+	LabelTypeSPDX
+	LabelTypeGitHash
+	LabelTypeSemVer
+	LabelTypeEmail
+)
+
+// LabelSchema defines required labels and their expected types.
+type LabelSchema map[string]LabelType
+
+// labelPair holds a key-value label entry.
+type labelPair struct{ Key, Value string }
+
+// collectLabelPairs extracts key-value pairs from a LABEL instruction.
+func collectLabelPairs(n *parser.Node) []labelPair {
+	var pairs []labelPair
+	if n == nil {
+		return pairs
+	}
+	var tokens []string
+	for tok := n.Next; tok != nil; tok = tok.Next {
+		tokens = append(tokens, strings.Trim(tok.Value, "\"'"))
+	}
+	for i := 0; i+2 < len(tokens); i += 3 {
+		pairs = append(pairs, labelPair{Key: tokens[i], Value: tokens[i+1]})
+	}
+	return pairs
+}
+
+// inSchema reports whether a key exists in the schema.
+func inSchema(schema LabelSchema, key string) bool {
+	_, ok := schema[key]
+	return ok
+}


### PR DESCRIPTION
## Summary
- add DL3050-DL3059 linter rules for labels, healthchecks, and RUN consolidation
- document the new DL3050-DL3059 checks

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689eaf9147c4833296f51d5c50190750