### PR TITLE
Implement Hadolint DL3040 rule for DNF cache cleanup

### DIFF
--- a/cmd/docker-lint/main.go
+++ b/cmd/docker-lint/main.go
@@ -53,6 +53,7 @@ func run(args []string, out io.Writer) error {
 	reg.Register(rules.NewAptNoInstallRecommends())
 	reg.Register(rules.NewAptPin())
 	reg.Register(rules.NewAptListsCleanup())
+	reg.Register(rules.NewDnfCacheCleanup())
 
 	ctx := context.Background()
 	var all []engine.Finding

--- a/docs/rules/DL3040.md
+++ b/docs/rules/DL3040.md
@@ -1,0 +1,2 @@
+# DL3040 - dnf clean all missing after dnf command
+Run `dnf clean all` (or remove `/var/cache/dnf`) in the same `RUN` after `dnf` or `microdnf` package operations to avoid leaving cache.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -21,6 +21,7 @@ The following Hadolint-compatible rules are implemented:
 - [DL3020](DL3020.md) - Use COPY instead of ADD for files and folders.
 - [DL3021](DL3021.md) - COPY with more than 2 arguments requires the last argument to end with /.
 
+- [DL3040](DL3040.md) - dnf clean all missing after dnf command.
 
 - [DL3060](DL3060.md) - `yarn cache clean` missing after `yarn install`.
 

--- a/internal/rules/DL3016.go
+++ b/internal/rules/DL3016.go
@@ -9,6 +9,9 @@ import (
 	"context"
 	"strings"
 
+	"github.com/google/shlex"
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
 	"github.com/asymmetric-effort/docker-lint/internal/engine"
 	"github.com/asymmetric-effort/docker-lint/internal/ir"
 )

--- a/internal/rules/DL3040.go
+++ b/internal/rules/DL3040.go
@@ -1,0 +1,108 @@
+package rules
+
+/*
+ * file: internal/rules/DL3040.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// dnfCacheCleanup ensures dnf or microdnf package operations clean metadata in the same layer.
+type dnfCacheCleanup struct{}
+
+// NewDnfCacheCleanup constructs the rule.
+func NewDnfCacheCleanup() engine.Rule { return dnfCacheCleanup{} }
+
+// ID returns the rule identifier.
+func (dnfCacheCleanup) ID() string { return "DL3040" }
+
+// Check scans RUN instructions for dnf/microdnf commands lacking cleanup.
+func (dnfCacheCleanup) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		segments := lowerSegments(splitRunSegments(n))
+		if needsDnfCleanup(segments) {
+			findings = append(findings, engine.Finding{
+				RuleID:  "DL3040",
+				Message: "dnf clean all missing after dnf command.",
+				Line:    n.StartLine,
+			})
+		}
+	}
+	return findings, nil
+}
+
+// needsDnfCleanup reports whether a dnf/microdnf operation lacks subsequent cleanup.
+func needsDnfCleanup(segments [][]string) bool {
+	lastOp := -1
+	lastClean := -1
+	for i, seg := range segments {
+		if isDnfOperation(seg) {
+			lastOp = i
+		}
+		if cleansDnfCache(seg) {
+			lastClean = i
+		}
+	}
+	return lastOp >= 0 && lastClean < lastOp
+}
+
+// isDnfOperation reports whether the segment invokes dnf/microdnf with modifying subcommands.
+func isDnfOperation(seg []string) bool {
+	if len(seg) < 2 {
+		return false
+	}
+	if seg[0] != "dnf" && seg[0] != "microdnf" {
+		return false
+	}
+	for _, t := range seg[1:] {
+		switch t {
+		case "install", "upgrade", "update", "groupinstall", "groupupdate", "distrosync", "autoremove", "remove":
+			return true
+		}
+	}
+	return false
+}
+
+// cleansDnfCache reports whether the segment removes dnf metadata/cache.
+func cleansDnfCache(seg []string) bool {
+	if len(seg) == 0 {
+		return false
+	}
+	switch seg[0] {
+	case "dnf", "microdnf":
+		for i := 1; i < len(seg); i++ {
+			if seg[i] == "clean" && i+1 < len(seg) && seg[i+1] == "all" {
+				return true
+			}
+		}
+		return false
+	case "rm":
+		joined := strings.Join(seg, " ")
+		if !strings.Contains(joined, "/var/cache/dnf") {
+			return false
+		}
+		flags := strings.Join(seg[1:], " ")
+		return strings.Contains(flags, "-rf") || strings.Contains(flags, "-fr") || strings.Contains(flags, "-r")
+	case "find":
+		joined := strings.Join(seg, " ")
+		if !strings.Contains(joined, "/var/cache/dnf") {
+			return false
+		}
+		return strings.Contains(joined, "-delete")
+	default:
+		return false
+	}
+}

--- a/internal/rules/DL3040_test.go
+++ b/internal/rules/DL3040_test.go
@@ -1,0 +1,136 @@
+// file: internal/rules/DL3040_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationDnfCacheCleanupID validates rule identity.
+func TestIntegrationDnfCacheCleanupID(t *testing.T) {
+	if NewDnfCacheCleanup().ID() != "DL3040" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationDnfCacheCleanupViolation detects missing cleanup after dnf install.
+func TestIntegrationDnfCacheCleanupViolation(t *testing.T) {
+	src := "FROM fedora\nRUN dnf install -y httpd\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewDnfCacheCleanup()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationDnfCacheCleanupClean ensures cleanup after install passes.
+func TestIntegrationDnfCacheCleanupClean(t *testing.T) {
+	src := "FROM fedora\nRUN dnf install -y httpd && dnf clean all\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewDnfCacheCleanup()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationMicrodnfCleanup verifies microdnf cleanup.
+func TestIntegrationMicrodnfCleanup(t *testing.T) {
+	src := "FROM fedora\nRUN microdnf install -y ca-certificates && microdnf clean all\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewDnfCacheCleanup()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationDnfCacheCleanupRM verifies explicit cache removal via rm.
+func TestIntegrationDnfCacheCleanupRM(t *testing.T) {
+	src := "FROM fedora\nRUN dnf install -y httpd && rm -rf /var/cache/dnf\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewDnfCacheCleanup()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationDnfCacheCleanupOrder ensures cleanup preceding install fails.
+func TestIntegrationDnfCacheCleanupOrder(t *testing.T) {
+	src := "FROM fedora\nRUN dnf clean all && dnf install -y httpd\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewDnfCacheCleanup()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationDnfCacheCleanupNil ensures nil documents are handled.
+func TestIntegrationDnfCacheCleanupNil(t *testing.T) {
+	r := NewDnfCacheCleanup()
+	if findings, err := r.Check(context.Background(), nil); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", findings, err)
+	}
+	if findings, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", findings, err)
+	}
+}


### PR DESCRIPTION
## Summary
- enforce DNF/microdnf commands clean cache (DL3040)
- document DL3040 and register new rule
- fix missing imports for DL3016 npm rule

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689eb3ab01c483328bc8956d1bd6bc47