### PR TITLE
feat: add DL3041 dnf upgrade rule

### DIFF
--- a/cmd/docker-lint/main.go
+++ b/cmd/docker-lint/main.go
@@ -53,6 +53,7 @@ func run(args []string, out io.Writer) error {
 	reg.Register(rules.NewAptNoInstallRecommends())
 	reg.Register(rules.NewAptPin())
 	reg.Register(rules.NewAptListsCleanup())
+	reg.Register(rules.NewDnfNoUpgrade())
 
 	ctx := context.Background()
 	var all []engine.Finding

--- a/docs/rules/DL3041.md
+++ b/docs/rules/DL3041.md
@@ -1,0 +1,3 @@
+# DL3041 - Avoid dnf upgrade or update in Dockerfiles
+
+Running `dnf upgrade` or `dnf update` (and their `microdnf` equivalents) updates all packages and can break reproducibility. Use a newer base image or install specific packages with pinned versions instead.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -22,6 +22,7 @@ The following Hadolint-compatible rules are implemented:
 - [DL3021](DL3021.md) - COPY with more than 2 arguments requires the last argument to end with /.
 
 
+- [DL3041](DL3041.md) - Avoid dnf upgrade or update in Dockerfiles.
 - [DL3060](DL3060.md) - `yarn cache clean` missing after `yarn install`.
 
 

--- a/internal/rules/DL3016.go
+++ b/internal/rules/DL3016.go
@@ -9,6 +9,9 @@ import (
 	"context"
 	"strings"
 
+	"github.com/google/shlex"
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
 	"github.com/asymmetric-effort/docker-lint/internal/engine"
 	"github.com/asymmetric-effort/docker-lint/internal/ir"
 )

--- a/internal/rules/DL3041.go
+++ b/internal/rules/DL3041.go
@@ -1,0 +1,65 @@
+package rules
+
+/*
+ * file: internal/rules/DL3041.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// dnfNoUpgrade warns against using dnf or microdnf upgrade/update.
+type dnfNoUpgrade struct{}
+
+// NewDnfNoUpgrade constructs the rule.
+func NewDnfNoUpgrade() engine.Rule { return dnfNoUpgrade{} }
+
+// ID returns the rule identifier.
+func (dnfNoUpgrade) ID() string { return "DL3041" }
+
+// Check scans RUN instructions for disallowed dnf upgrade or update usage.
+func (dnfNoUpgrade) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		segs := lowerSegments(splitRunSegments(n))
+		for _, seg := range segs {
+			if isDnfUpgrade(seg) {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL3041",
+					Message: "Avoid dnf upgrade or update; use a newer base image or install specific packages with pinned versions instead.",
+					Line:    n.StartLine,
+				})
+				break
+			}
+		}
+	}
+	return findings, nil
+}
+
+// isDnfUpgrade reports whether the segment invokes dnf or microdnf upgrade/update.
+func isDnfUpgrade(tokens []string) bool {
+	if len(tokens) == 0 {
+		return false
+	}
+	if tokens[0] != "dnf" && tokens[0] != "microdnf" {
+		return false
+	}
+	for _, t := range tokens[1:] {
+		if strings.HasPrefix(t, "-") {
+			continue
+		}
+		return t == "upgrade" || t == "update"
+	}
+	return false
+}

--- a/internal/rules/DL3041_test.go
+++ b/internal/rules/DL3041_test.go
@@ -1,0 +1,94 @@
+// file: internal/rules/DL3041_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationDnfNoUpgradeID validates rule identity.
+func TestIntegrationDnfNoUpgradeID(t *testing.T) {
+	if NewDnfNoUpgrade().ID() != "DL3041" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationDnfNoUpgradeViolation detects dnf upgrade usage.
+func TestIntegrationDnfNoUpgradeViolation(t *testing.T) {
+	src := "FROM quay.io/ubi9/ubi\nRUN dnf -y upgrade\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewDnfNoUpgrade()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationMicrodnfNoUpgradeViolation detects microdnf update usage.
+func TestIntegrationMicrodnfNoUpgradeViolation(t *testing.T) {
+	src := "FROM registry.access.redhat.com/ubi9/ubi\nRUN microdnf update -y\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewDnfNoUpgrade()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationDnfNoUpgradeClean ensures compliant Dockerfiles pass.
+func TestIntegrationDnfNoUpgradeClean(t *testing.T) {
+	src := "FROM fedora\nRUN dnf install -y httpd\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewDnfNoUpgrade()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationDnfNoUpgradeNil ensures graceful handling of nil input.
+func TestIntegrationDnfNoUpgradeNil(t *testing.T) {
+	r := NewDnfNoUpgrade()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}


### PR DESCRIPTION
## Summary
- warn when `dnf`/`microdnf` runs `upgrade` or `update`
- document DL3041 and register rule in CLI
- fix missing imports in DL3016 to keep rules package building

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689eb3ea85748332b7b877dbea6d3dfa