### PR TITLE
Fix go vet failure due to duplicate run segment parser

### DIFF
--- a/internal/rules/run_commands.go
+++ b/internal/rules/run_commands.go
@@ -49,9 +49,10 @@ func commandNames(tokens []string) []string {
 	return cmds
 }
 
-// splitRunSegments tokenizes a RUN instruction and splits it into command segments.
-// It handles both shell-form and JSON-form RUN instructions.
-func splitRunSegments(n *parser.Node) [][]string {
+// splitRunSegmentsNpm tokenizes a RUN instruction and splits it into command
+// segments while preserving original token casing. It is tailored for rules
+// that require case-sensitive analysis such as npm package checks.
+func splitRunSegmentsNpm(n *parser.Node) [][]string {
 	if n == nil || n.Next == nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary
- rename run command segmentation helper and preserve token casing for npm checks

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689eb4e8d000833280c75167965a3b67