### PR TITLE
refactor: reuse run segment parsing

### DIFF
--- a/internal/rules/DL3016.go
+++ b/internal/rules/DL3016.go
@@ -9,9 +9,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/google/shlex"
-	"github.com/moby/buildkit/frontend/dockerfile/parser"
-
 	"github.com/asymmetric-effort/docker-lint/internal/engine"
 	"github.com/asymmetric-effort/docker-lint/internal/ir"
 )
@@ -35,7 +32,7 @@ func (pinNpmVersion) Check(ctx context.Context, d *ir.Document) ([]engine.Findin
 		if !strings.EqualFold(n.Value, "run") {
 			continue
 		}
-		segments := splitRunSegmentsNpm(n)
+		segments := splitRunSegments(n)
 		for _, seg := range segments {
 			if len(seg) == 0 {
 				continue

--- a/internal/rules/run_commands.go
+++ b/internal/rules/run_commands.go
@@ -49,52 +49,11 @@ func commandNames(tokens []string) []string {
 	return cmds
 }
 
-// splitRunSegments tokenizes a RUN instruction and splits it into command segments.
-// It handles both shell-form and JSON-form RUN instructions.
-func splitRunSegments(n *parser.Node) [][]string {
-	if n == nil || n.Next == nil {
-		return nil
-	}
-	var tokens []string
-	if n.Attributes != nil && n.Attributes["json"] {
-		for tok := n.Next; tok != nil; tok = tok.Next {
-			tokens = append(tokens, tok.Value)
-		}
-	} else {
-		t, err := shlex.Split(n.Next.Value)
-		if err != nil {
-			return nil
-		}
-		tokens = t
-	}
-	var segments [][]string
-	var current []string
-	for _, tok := range tokens {
-		switch tok {
-		case "&&", "||", "|", ";":
-			if len(current) > 0 {
-				segments = append(segments, current)
-				current = nil
-			}
-		default:
-			current = append(current, tok)
-		}
-	}
-	if len(current) > 0 {
-		segments = append(segments, current)
-	}
-	return segments
-}
-
 // lowerSegments returns a lowercase copy of each segment.
 func lowerSegments(segs [][]string) [][]string {
 	out := make([][]string, len(segs))
 	for i, seg := range segs {
-		outSeg := make([]string, len(seg))
-		for j, s := range seg {
-			outSeg[j] = strings.ToLower(s)
-		}
-		out[i] = outSeg
+		out[i] = lowerSlice(seg)
 	}
 	return out
 }


### PR DESCRIPTION
## Summary
- Remove duplicate splitRunSegments implementation and reuse centralized helper
- Simplify lowerSegments by delegating to lowerSlice
- Apply shared run segment parser in DL3016 rule

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689eb5b4b5b88332a8681b86ec1c3d04