### PR TITLE
remove unused imports in DL3016 rule

### DIFF
--- a/internal/rules/DL3016.go
+++ b/internal/rules/DL3016.go
@@ -9,9 +9,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/google/shlex"
-	"github.com/moby/buildkit/frontend/dockerfile/parser"
-
 	"github.com/asymmetric-effort/docker-lint/internal/engine"
 	"github.com/asymmetric-effort/docker-lint/internal/ir"
 )


### PR DESCRIPTION
## Summary
- clean up DL3016 rule by removing leftover shlex and parser imports

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689eb67199788332b257d715264ffa63