### PR TITLE
feat: add DL3042 rule for combining package manager RUNs

### DIFF
--- a/docs/rules/DL3042.md
+++ b/docs/rules/DL3042.md
@@ -1,0 +1,2 @@
+# DL3042 - Combine consecutive RUN instructions that use the same package manager
+Merge related package manager commands into a single RUN to reduce layers and improve caching.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -24,6 +24,7 @@ The following Hadolint-compatible rules are implemented:
 - [DL3040](DL3040.md) - dnf clean all missing after dnf command.
 
 - [DL3041](DL3041.md) - Avoid dnf upgrade or update in Dockerfiles.
+- [DL3042](DL3042.md) - Combine consecutive RUN instructions that use the same package manager.
 - [DL3060](DL3060.md) - `yarn cache clean` missing after `yarn install`.
 
 

--- a/internal/rules/DL3016.go
+++ b/internal/rules/DL3016.go
@@ -9,9 +9,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/google/shlex"
-	"github.com/moby/buildkit/frontend/dockerfile/parser"
-
 	"github.com/asymmetric-effort/docker-lint/internal/engine"
 	"github.com/asymmetric-effort/docker-lint/internal/ir"
 )

--- a/internal/rules/DL3042.go
+++ b/internal/rules/DL3042.go
@@ -1,0 +1,113 @@
+package rules
+
+/*
+ * file: internal/rules/DL3042.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+)
+
+// combinePackageRuns flags consecutive RUN instructions using the same package manager.
+type combinePackageRuns struct{}
+
+// NewCombinePackageRuns constructs the rule.
+func NewCombinePackageRuns() engine.Rule { return combinePackageRuns{} }
+
+// ID returns the rule identifier.
+func (combinePackageRuns) ID() string { return "DL3042" }
+
+// Check detects consecutive package manager RUN instructions.
+func (combinePackageRuns) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	prev := ""
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			if strings.EqualFold(n.Value, "#") {
+				continue
+			}
+			prev = ""
+			continue
+		}
+		pm := runPackageManager(n)
+		if pm != "" && pm == prev {
+			findings = append(findings, engine.Finding{
+				RuleID:  "DL3042",
+				Message: "Combine consecutive RUN instructions that use the same package manager.",
+				Line:    n.StartLine,
+			})
+		}
+		prev = pm
+	}
+	return findings, nil
+}
+
+// runPackageManager determines the package manager family used in a RUN instruction.
+func runPackageManager(n *parser.Node) string {
+	fams := make(map[string]struct{})
+	for _, seg := range splitRunSegments(n) {
+		if fam := packageManagerFamily(seg); fam != "" {
+			fams[fam] = struct{}{}
+		}
+	}
+	if len(fams) != 1 {
+		return ""
+	}
+	for k := range fams {
+		return k
+	}
+	return ""
+}
+
+// packageManagerFamily returns the package manager family for a command segment.
+func packageManagerFamily(seg []string) string {
+	if len(seg) < 2 {
+		return ""
+	}
+	cmd := seg[0]
+	i := 1
+	for i < len(seg) && strings.HasPrefix(seg[i], "-") {
+		i++
+	}
+	if i >= len(seg) {
+		return ""
+	}
+	sub := seg[i]
+	switch cmd {
+	case "apt-get", "apt":
+		switch sub {
+		case "update", "install", "upgrade", "remove", "clean":
+			return "apt"
+		}
+	case "apk":
+		switch sub {
+		case "add", "del", "update", "upgrade", "fix", "cache":
+			return "apk"
+		}
+	case "dnf", "microdnf":
+		switch sub {
+		case "update", "install", "upgrade", "remove", "clean":
+			return "dnf"
+		}
+	case "yum":
+		switch sub {
+		case "update", "install", "upgrade", "remove", "clean":
+			return "yum"
+		}
+	case "zypper":
+		switch sub {
+		case "update", "install", "upgrade", "remove", "clean":
+			return "zypper"
+		}
+	}
+	return ""
+}

--- a/internal/rules/DL3042_test.go
+++ b/internal/rules/DL3042_test.go
@@ -1,0 +1,115 @@
+// file: internal/rules/DL3042_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationCombinePackageRunsID validates rule identity.
+func TestIntegrationCombinePackageRunsID(t *testing.T) {
+	if NewCombinePackageRuns().ID() != "DL3042" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationCombinePackageRunsViolation detects separated apt-get operations.
+func TestIntegrationCombinePackageRunsViolation(t *testing.T) {
+	src := "FROM ubuntu\nRUN apt-get update\nRUN apt-get install -y curl\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewCombinePackageRuns()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationCombinePackageRunsDifferentManagers ensures different managers are allowed.
+func TestIntegrationCombinePackageRunsDifferentManagers(t *testing.T) {
+	src := "FROM ubuntu\nRUN apt-get update && apt-get install -y curl\nRUN apk add bash\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewCombinePackageRuns()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationCombinePackageRunsBreak ensures unrelated RUN breaks sequence.
+func TestIntegrationCombinePackageRunsBreak(t *testing.T) {
+	src := "FROM ubuntu\nRUN apt-get update\nRUN echo ok\nRUN apt-get install -y curl\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewCombinePackageRuns()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationCombinePackageRunsClean ensures combined operations pass.
+func TestIntegrationCombinePackageRunsClean(t *testing.T) {
+	src := "FROM ubuntu\nRUN apt-get update && apt-get install -y curl\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewCombinePackageRuns()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationCombinePackageRunsNil ensures nil documents are handled.
+func TestIntegrationCombinePackageRunsNil(t *testing.T) {
+	r := NewCombinePackageRuns()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add DL3042 to flag consecutive RUNs using same package manager
- document new rule and update rule index
- fix unused imports in DL3016 to keep tests compiling

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689eb6f6eea8833288d1f6025fb398d5