### PR TITLE
feat: enforce OS version tags in FROM images

### DIFF
--- a/cmd/docker-lint/main.go
+++ b/cmd/docker-lint/main.go
@@ -50,6 +50,7 @@ func run(args []string, out io.Writer) error {
 
 	reg := engine.NewRegistry()
 	reg.Register(rules.NewNoLatestTag())
+	reg.Register(rules.NewRequireOSVersionTag())
 	reg.Register(rules.NewAptNoInstallRecommends())
 	reg.Register(rules.NewAptPin())
 	reg.Register(rules.NewAptListsCleanup())

--- a/cmd/docker-lint/main_integration_test.go
+++ b/cmd/docker-lint/main_integration_test.go
@@ -26,11 +26,18 @@ func TestIntegrationRunDetectsLatest(t *testing.T) {
 	if err := json.Unmarshal(out.Bytes(), &findings); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if len(findings) != 1 {
-		t.Fatalf("expected 1 finding, got %d", len(findings))
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(findings))
 	}
-	if findings[0].RuleID != rules.NewNoLatestTag().ID() {
-		t.Fatalf("unexpected rule id: %s", findings[0].RuleID)
+	ids := map[string]struct{}{}
+	for _, f := range findings {
+		ids[f.RuleID] = struct{}{}
+	}
+	if _, ok := ids[rules.NewNoLatestTag().ID()]; !ok {
+		t.Fatalf("missing DL3007 finding")
+	}
+	if _, ok := ids[rules.NewRequireOSVersionTag().ID()]; !ok {
+		t.Fatalf("missing DL3043 finding")
 	}
 }
 
@@ -131,8 +138,8 @@ func TestIntegrationRunGlob(t *testing.T) {
 	if err := json.Unmarshal(out.Bytes(), &findings); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if len(findings) != 1 {
-		t.Fatalf("expected 1 finding, got %d", len(findings))
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(findings))
 	}
 }
 
@@ -168,7 +175,7 @@ func TestIntegrationRunDoubleStar(t *testing.T) {
 	if err := json.Unmarshal(out.Bytes(), &findings); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if len(findings) != 2 {
-		t.Fatalf("expected 2 findings, got %d", len(findings))
+	if len(findings) != 4 {
+		t.Fatalf("expected 4 findings, got %d", len(findings))
 	}
 }

--- a/docs/rules/DL3043.md
+++ b/docs/rules/DL3043.md
@@ -1,0 +1,4 @@
+# DL3043 - Specify OS version tag for base images
+
+FROM instructions that reference OS-based images must include an explicit version tag instead of floating tags like `latest` or leaving the tag unset. Pinning the operating system version aids reproducibility and security tracking.
+

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -24,6 +24,7 @@ The following Hadolint-compatible rules are implemented:
 - [DL3040](DL3040.md) - dnf clean all missing after dnf command.
 
 - [DL3041](DL3041.md) - Avoid dnf upgrade or update in Dockerfiles.
+- [DL3043](DL3043.md) - Specify OS version tag for base images.
 - [DL3060](DL3060.md) - `yarn cache clean` missing after `yarn install`.
 
 

--- a/internal/rules/DL3016.go
+++ b/internal/rules/DL3016.go
@@ -9,9 +9,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/google/shlex"
-	"github.com/moby/buildkit/frontend/dockerfile/parser"
-
 	"github.com/asymmetric-effort/docker-lint/internal/engine"
 	"github.com/asymmetric-effort/docker-lint/internal/ir"
 )

--- a/internal/rules/DL3043.go
+++ b/internal/rules/DL3043.go
@@ -1,0 +1,119 @@
+package rules
+
+/*
+ * file: internal/rules/DL3043.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+	"unicode"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// requireOSVersionTag ensures OS base images specify explicit version tags.
+type requireOSVersionTag struct{}
+
+// NewRequireOSVersionTag constructs the rule.
+func NewRequireOSVersionTag() engine.Rule { return requireOSVersionTag{} }
+
+// ID returns the rule identifier.
+func (requireOSVersionTag) ID() string { return "DL3043" }
+
+// Check validates that OS images include explicit numeric version tags.
+func (requireOSVersionTag) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil {
+		return findings, nil
+	}
+	aliases := map[string]struct{}{}
+	for _, s := range d.Stages {
+		from := s.From
+		if from == "" {
+			if s.Name != "" {
+				aliases[strings.ToLower(s.Name)] = struct{}{}
+			}
+			continue
+		}
+		if _, ok := aliases[strings.ToLower(from)]; ok {
+			if s.Name != "" {
+				aliases[strings.ToLower(s.Name)] = struct{}{}
+			}
+			continue
+		}
+		if needsOSVersionTag(from) {
+			line := 0
+			if s.Node != nil {
+				line = s.Node.StartLine
+			}
+			findings = append(findings, engine.Finding{
+				RuleID:  "DL3043",
+				Message: "Specify OS version tag in FROM image",
+				Line:    line,
+			})
+		}
+		if s.Name != "" {
+			aliases[strings.ToLower(s.Name)] = struct{}{}
+		}
+	}
+	return findings, nil
+}
+
+// needsOSVersionTag reports if the image is OS-based and lacks a pinned version.
+func needsOSVersionTag(image string) bool {
+	lower := strings.ToLower(image)
+	if lower == "scratch" {
+		return false
+	}
+	if strings.HasPrefix(lower, "$") {
+		return false
+	}
+	if !isOSImage(lower) {
+		return false
+	}
+	name := lower
+	if idx := strings.Index(name, "@"); idx != -1 {
+		name = name[:idx]
+	}
+	parts := strings.Split(name, ":")
+	if len(parts) == 1 {
+		return true
+	}
+	tag := parts[len(parts)-1]
+	floating := map[string]struct{}{"latest": {}, "stable": {}, "edge": {}, "rolling": {}}
+	if _, ok := floating[tag]; ok {
+		return true
+	}
+	for _, r := range tag {
+		if unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
+}
+
+// isOSImage determines if the image references a known OS base.
+func isOSImage(image string) bool {
+	name := image
+	if idx := strings.Index(name, "@"); idx != -1 {
+		name = name[:idx]
+	}
+	if idx := strings.Index(name, ":"); idx != -1 {
+		name = name[:idx]
+	}
+	parts := strings.Split(name, "/")
+	osNames := map[string]struct{}{
+		"alpine": {}, "ubuntu": {}, "debian": {}, "fedora": {}, "centos": {},
+		"rockylinux": {}, "rocky": {}, "almalinux": {}, "opensuse": {}, "suse": {},
+		"archlinux": {}, "arch": {}, "amazonlinux": {}, "oraclelinux": {},
+	}
+	for _, p := range parts {
+		if _, ok := osNames[p]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rules/DL3043_test.go
+++ b/internal/rules/DL3043_test.go
@@ -1,0 +1,92 @@
+// file: internal/rules/DL3043_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationRequireOSVersionTagID validates rule identity.
+func TestIntegrationRequireOSVersionTagID(t *testing.T) {
+	if NewRequireOSVersionTag().ID() != "DL3043" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationRequireOSVersionTagViolations detects missing or floating OS tags.
+func TestIntegrationRequireOSVersionTagViolations(t *testing.T) {
+	r := NewRequireOSVersionTag()
+	doc := &ir.Document{Stages: []*ir.Stage{
+		{Index: 0, From: "ubuntu", Node: &parser.Node{StartLine: 1}},
+		{Index: 1, From: "debian:stable", Node: &parser.Node{StartLine: 2}},
+		{Index: 2, From: "alpine:3.19", Node: &parser.Node{StartLine: 3}},
+	}}
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("expected two findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationRequireOSVersionTagClean ensures compliant images pass.
+func TestIntegrationRequireOSVersionTagClean(t *testing.T) {
+	r := NewRequireOSVersionTag()
+	doc := &ir.Document{Stages: []*ir.Stage{
+		{Index: 0, From: "ubuntu:22.04", Node: &parser.Node{StartLine: 1}},
+		{Index: 1, From: "golang:1.21", Node: &parser.Node{StartLine: 2}},
+	}}
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationRequireOSVersionTagAlias ensures alias references are exempt.
+func TestIntegrationRequireOSVersionTagAlias(t *testing.T) {
+	r := NewRequireOSVersionTag()
+	doc := &ir.Document{Stages: []*ir.Stage{
+		{Index: 0, From: "alpine:3.19", Name: "base", Node: &parser.Node{StartLine: 1}},
+		{Index: 1, From: "base", Node: &parser.Node{StartLine: 2}},
+	}}
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationRequireOSVersionTagScratchAndVariable allows scratch and variable images.
+func TestIntegrationRequireOSVersionTagScratchAndVariable(t *testing.T) {
+	r := NewRequireOSVersionTag()
+	doc := &ir.Document{Stages: []*ir.Stage{
+		{Index: 0, From: "scratch", Node: &parser.Node{StartLine: 1}},
+		{Index: 1, From: "$BASE", Node: &parser.Node{StartLine: 2}},
+	}}
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationRequireOSVersionTagNilDocument ensures graceful handling of nil input.
+func TestIntegrationRequireOSVersionTagNilDocument(t *testing.T) {
+	r := NewRequireOSVersionTag()
+	if findings, err := r.Check(context.Background(), nil); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", findings, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add DL3043 rule to warn when OS images omit explicit version tags or use floating tags
- document DL3043 and register rule with CLI
- extend integration tests to cover new rule

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689eb75726988332bc4d981ad9be1b0e