### PR TITLE
feat: add DL3044 rule for dnf version pinning

### DIFF
--- a/docs/rules/DL3044.md
+++ b/docs/rules/DL3044.md
@@ -1,0 +1,2 @@
+# DL3044 - Specify version with dnf/microdnf install
+Pin all packages when using `dnf install` or `microdnf install` by including an explicit version (e.g., `pkg-1.2.3`).

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -24,6 +24,7 @@ The following Hadolint-compatible rules are implemented:
 - [DL3040](DL3040.md) - dnf clean all missing after dnf command.
 
 - [DL3041](DL3041.md) - Avoid dnf upgrade or update in Dockerfiles.
+- [DL3044](DL3044.md) - Specify version with dnf/microdnf install.
 - [DL3060](DL3060.md) - `yarn cache clean` missing after `yarn install`.
 
 

--- a/internal/rules/DL3044.go
+++ b/internal/rules/DL3044.go
@@ -1,0 +1,91 @@
+package rules
+
+/*
+ * file: internal/rules/DL3044.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// dnfVersionPin enforces version pinning for dnf/microdnf installs.
+type dnfVersionPin struct{}
+
+// NewDnfVersionPin constructs the rule.
+func NewDnfVersionPin() engine.Rule { return dnfVersionPin{} }
+
+// ID returns the rule identifier.
+func (dnfVersionPin) ID() string { return "DL3044" }
+
+// Check scans RUN instructions for unpinned dnf or microdnf installs.
+func (dnfVersionPin) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		segments := lowerSegments(splitRunSegments(n))
+		for _, seg := range segments {
+			if hasUnpinnedDnfInstall(seg) {
+				findings = append(findings, engine.Finding{
+					RuleID:  "DL3044",
+					Message: "Specify version with dnf/microdnf install. Use 'pkg-<version>' format for every installed package.",
+					Line:    n.StartLine,
+				})
+				break
+			}
+		}
+	}
+	return findings, nil
+}
+
+// hasUnpinnedDnfInstall reports whether tokens invoke dnf or microdnf install with unpinned packages.
+func hasUnpinnedDnfInstall(tokens []string) bool {
+	if len(tokens) == 0 {
+		return false
+	}
+	if tokens[0] != "dnf" && tokens[0] != "microdnf" {
+		return false
+	}
+	idx := -1
+	for i := 1; i < len(tokens); i++ {
+		t := tokens[i]
+		if t == "install" {
+			idx = i
+			break
+		}
+		if !strings.HasPrefix(t, "-") {
+			return false
+		}
+	}
+	if idx == -1 {
+		return false
+	}
+	return unpinnedDnfPackages(tokens[idx+1:])
+}
+
+// unpinnedDnfPackages checks package arguments for version pins.
+func unpinnedDnfPackages(args []string) bool {
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") {
+			continue
+		}
+		dash := strings.Index(a, "-")
+		if dash <= 0 {
+			return true
+		}
+		ver := a[dash+1:]
+		if ver == "" || strings.HasPrefix(ver, "-") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rules/DL3044_test.go
+++ b/internal/rules/DL3044_test.go
@@ -1,0 +1,115 @@
+// file: internal/rules/DL3044_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationDnfVersionPinID validates rule identity.
+func TestIntegrationDnfVersionPinID(t *testing.T) {
+	if NewDnfVersionPin().ID() != "DL3044" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationDnfVersionPinViolation detects unpinned dnf installs.
+func TestIntegrationDnfVersionPinViolation(t *testing.T) {
+	src := "FROM fedora\nRUN dnf install -y curl\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewDnfVersionPin()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationMicrodnfVersionPinViolation detects unpinned microdnf installs.
+func TestIntegrationMicrodnfVersionPinViolation(t *testing.T) {
+	src := "FROM registry.access.redhat.com/ubi9/ubi\nRUN microdnf install -y python3 make\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewDnfVersionPin()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationDnfVersionPinClean ensures pinned installs pass.
+func TestIntegrationDnfVersionPinClean(t *testing.T) {
+	src := "FROM fedora\nRUN dnf install -y curl-7.76.1-5.fc34 make-4.3-3.fc34\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewDnfVersionPin()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationDnfVersionPinVariable ensures variable pins are allowed.
+func TestIntegrationDnfVersionPinVariable(t *testing.T) {
+	src := "FROM fedora\nARG CURL_VER=7.76.1-5.fc34\nRUN dnf install -y curl-${CURL_VER}\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewDnfVersionPin()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationDnfVersionPinNil ensures graceful handling of nil input.
+func TestIntegrationDnfVersionPinNil(t *testing.T) {
+	r := NewDnfVersionPin()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}


### PR DESCRIPTION
## Summary
- enforce explicit version pins in `dnf`/`microdnf` installs (DL3044)
- document DL3044 and list in rules index

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689eb7e232d88332bbb383997f524f01