### PR TITLE
Implement DL3045 to warn on unpinned COPY --from images

### DIFF
--- a/docs/rules/DL3045.md
+++ b/docs/rules/DL3045.md
@@ -1,0 +1,4 @@
+# DL3045 - COPY --from without digest pinning for external image
+
+Use a digest when copying from an external image with `COPY --from`. Add
+`@sha256:<digest>` to the image reference to ensure reproducible builds.

--- a/internal/rules/DL3045.go
+++ b/internal/rules/DL3045.go
@@ -1,0 +1,66 @@
+// file: internal/rules/DL3045.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// copyFromExternalDigest ensures COPY --from external images include a digest.
+type copyFromExternalDigest struct{}
+
+// NewCopyFromExternalDigest constructs the rule.
+func NewCopyFromExternalDigest() engine.Rule { return copyFromExternalDigest{} }
+
+// ID returns the rule identifier.
+func (copyFromExternalDigest) ID() string { return "DL3045" }
+
+// Check flags external COPY --from references lacking a digest.
+func (copyFromExternalDigest) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	aliases := map[string]struct{}{}
+	for _, n := range d.AST.Children {
+		if strings.EqualFold(n.Value, "from") {
+			if name := stageAlias(n); name != "" {
+				aliases[strings.ToLower(name)] = struct{}{}
+			}
+			continue
+		}
+		if !strings.EqualFold(n.Value, "copy") {
+			continue
+		}
+		from, ok := copyFromFlag(n)
+		if !ok {
+			continue
+		}
+		lf := strings.ToLower(from)
+		if lf == "scratch" {
+			continue
+		}
+		if strings.HasPrefix(from, "$") {
+			continue
+		}
+		if _, ok := aliases[lf]; ok {
+			continue
+		}
+		if _, err := strconv.Atoi(from); err == nil {
+			continue
+		}
+		if !strings.Contains(lf, "@sha256:") {
+			findings = append(findings, engine.Finding{
+				RuleID:  "DL3045",
+				Message: "COPY --from without digest pinning for external image.",
+				Line:    n.StartLine,
+			})
+		}
+	}
+	return findings, nil
+}

--- a/internal/rules/DL3045_test.go
+++ b/internal/rules/DL3045_test.go
@@ -1,0 +1,136 @@
+// file: internal/rules/DL3045_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationCopyFromExternalDigestID validates rule identity.
+func TestIntegrationCopyFromExternalDigestID(t *testing.T) {
+	if NewCopyFromExternalDigest().ID() != "DL3045" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationCopyFromExternalDigestViolation detects missing digests.
+func TestIntegrationCopyFromExternalDigestViolation(t *testing.T) {
+	src := "FROM alpine\nCOPY --from=ubuntu:22.04 /bin/bash /bin/bash\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewCopyFromExternalDigest()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationCopyFromExternalDigestCompliant ensures digest-pinned images pass.
+func TestIntegrationCopyFromExternalDigestCompliant(t *testing.T) {
+	src := "FROM alpine\nCOPY --from=ubuntu:22.04@sha256:deadbeef /bin/bash /bin/bash\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewCopyFromExternalDigest()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationCopyFromExternalDigestStageAlias ignores intra-file stages.
+func TestIntegrationCopyFromExternalDigestStageAlias(t *testing.T) {
+	src := "FROM alpine AS build\nCOPY --from=build /src /dest\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewCopyFromExternalDigest()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationCopyFromExternalDigestScratch skips scratch source.
+func TestIntegrationCopyFromExternalDigestScratch(t *testing.T) {
+	src := "FROM alpine\nCOPY --from=scratch /bin/bash /bin/bash\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewCopyFromExternalDigest()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationCopyFromExternalDigestNumeric skips numeric stage references.
+func TestIntegrationCopyFromExternalDigestNumeric(t *testing.T) {
+	src := "FROM alpine\nFROM alpine AS build\nCOPY --from=0 /src /dest\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build doc: %v", err)
+	}
+	r := NewCopyFromExternalDigest()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationCopyFromExternalDigestNil ensures graceful handling of nil input.
+func TestIntegrationCopyFromExternalDigestNil(t *testing.T) {
+	r := NewCopyFromExternalDigest()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+	if f, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", f, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add DL3045 rule detecting external `COPY --from` sources lacking `@sha256` digest
- document the new rule
- add comprehensive unit tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689eb80dd1348332a0728154cc09f229