### PR TITLE
Handle empty required label values (DL3051)

### DIFF
--- a/docs/rules/DL3051.md
+++ b/docs/rules/DL3051.md
@@ -1,3 +1,34 @@
 # DL3051 - Label value is empty
 
-Labels defined in the schema must have a non-empty value.
+Labels defined in the schema must have a non-empty value. Hadolint only
+evaluates this rule when a label schema or `--require-label` is
+provided. If a required key appears with an empty value (after trimming
+whitespace), a finding is reported.
+
+## Examples
+
+```Dockerfile
+FROM alpine:3.19
+LABEL org.opencontainers.image.source=""
+```
+
+```Dockerfile
+FROM alpine:3.19
+LABEL org.opencontainers.image.source="https://example.org/repo"  # compliant
+```
+
+When the same label key is assigned multiple times, the last assignment
+is used. Only the final value is checked.
+
+```Dockerfile
+FROM scratch
+LABEL foo=""       # ignored
+LABEL foo="bar"   # OK
+```
+
+Whitespace-only values are also considered empty:
+
+```Dockerfile
+FROM scratch
+LABEL foo="   "
+```

--- a/internal/rules/DL3051_test.go
+++ b/internal/rules/DL3051_test.go
@@ -60,6 +60,65 @@ func TestLabelNotEmptyClean(t *testing.T) {
 	}
 }
 
+func TestLabelNotEmptyWhitespace(t *testing.T) {
+	src := "FROM scratch\nLABEL foo=\" \"\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	schema := LabelSchema{"foo": LabelTypeString}
+	r := NewLabelNotEmpty(schema)
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+func TestLabelNotEmptyOverwrite(t *testing.T) {
+	src := "FROM scratch\nLABEL foo=\"\"\nLABEL foo=\"bar\"\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	schema := LabelSchema{"foo": LabelTypeString}
+	r := NewLabelNotEmpty(schema)
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+
+	src = "FROM scratch\nLABEL foo=\"bar\"\nLABEL foo=\"\"\n"
+	res, err = parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err = ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	findings, err = r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
 func TestLabelNotEmptyNilDocument(t *testing.T) {
 	r := NewLabelNotEmpty(nil)
 	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {


### PR DESCRIPTION
## Summary
- ensure DL3051 trims whitespace and respects final label assignment
- add tests for whitespace values and overwrite scenarios
- document rule details and examples

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689eb9d398208332a37a3e965c6f9dc6