### PR TITLE
Add DL3047 rule for APK cache cleanup

### DIFF
--- a/docs/rules/DL3047.md
+++ b/docs/rules/DL3047.md
@@ -1,0 +1,3 @@
+# DL3047 - Clean apk cache after installing packages
+
+Clean APK cache after installing packages. Use `apk add --no-cache` or remove `/var/cache/apk/*` in the same RUN instruction.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -24,6 +24,7 @@ The following Hadolint-compatible rules are implemented:
 - [DL3040](DL3040.md) - dnf clean all missing after dnf command.
 
 - [DL3041](DL3041.md) - Avoid dnf upgrade or update in Dockerfiles.
+- [DL3047](DL3047.md) - Clean apk cache after installing packages.
 - [DL3060](DL3060.md) - `yarn cache clean` missing after `yarn install`.
 
 

--- a/internal/rules/DL3047.go
+++ b/internal/rules/DL3047.go
@@ -1,0 +1,82 @@
+package rules
+
+/*
+ * file: internal/rules/DL3047.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// apkCacheCleanup ensures APK cache is cleared or avoided after installation.
+type apkCacheCleanup struct{}
+
+// NewApkCacheCleanup constructs the rule.
+func NewApkCacheCleanup() engine.Rule { return apkCacheCleanup{} }
+
+// ID returns the rule identifier.
+func (apkCacheCleanup) ID() string { return "DL3047" }
+
+// Check verifies apk add usage includes --no-cache or cache removal.
+func (apkCacheCleanup) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		if !strings.EqualFold(n.Value, "run") {
+			continue
+		}
+		segments := lowerSegments(splitRunSegments(n))
+		if needsApkCacheCleanup(segments) {
+			findings = append(findings, engine.Finding{
+				RuleID:  "DL3047",
+				Message: "Clean apk cache after installing packages. Use 'apk add --no-cache' or remove /var/cache/apk/* in the same RUN.",
+				Line:    n.StartLine,
+			})
+		}
+	}
+	return findings, nil
+}
+
+// needsApkCacheCleanup reports whether an apk add occurred without --no-cache and without subsequent cache removal.
+func needsApkCacheCleanup(segments [][]string) bool {
+	lastInstall := -1
+	installHasNoCache := false
+	lastCleanup := -1
+	for i, seg := range segments {
+		if isApkAdd(seg) {
+			lastInstall = i
+			installHasNoCache = hasNoCache(seg)
+		}
+		if removesApkCache(seg) {
+			lastCleanup = i
+		}
+	}
+	return lastInstall >= 0 && !installHasNoCache && lastCleanup < lastInstall
+}
+
+// removesApkCache reports whether segment removes /var/cache/apk files.
+func removesApkCache(seg []string) bool {
+	if len(seg) == 0 {
+		return false
+	}
+	joined := strings.Join(seg, " ")
+	if !strings.Contains(joined, "/var/cache/apk") {
+		return false
+	}
+	switch seg[0] {
+	case "rm":
+		flags := strings.Join(seg[1:], " ")
+		return strings.Contains(flags, "-rf") || strings.Contains(flags, "-fr") || strings.Contains(flags, "-r")
+	case "find":
+		return strings.Contains(joined, "-delete")
+	default:
+		return false
+	}
+}

--- a/internal/rules/DL3047_test.go
+++ b/internal/rules/DL3047_test.go
@@ -1,0 +1,115 @@
+// file: internal/rules/DL3047_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// TestIntegrationApkCacheCleanupID validates rule identity.
+func TestIntegrationApkCacheCleanupID(t *testing.T) {
+	if NewApkCacheCleanup().ID() != "DL3047" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+// TestIntegrationApkCacheCleanupViolation reports missing cleanup without no-cache.
+func TestIntegrationApkCacheCleanupViolation(t *testing.T) {
+	src := "FROM alpine\nRUN apk add curl\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewApkCacheCleanup()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+// TestIntegrationApkCacheCleanupNoCache passes with --no-cache flag.
+func TestIntegrationApkCacheCleanupNoCache(t *testing.T) {
+	src := "FROM alpine\nRUN apk add --no-cache curl\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewApkCacheCleanup()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationApkCacheCleanupRemove removes cache manually.
+func TestIntegrationApkCacheCleanupRemove(t *testing.T) {
+	src := "FROM alpine\nRUN apk add curl && rm -rf /var/cache/apk/*\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewApkCacheCleanup()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationApkCacheCleanupFindDelete uses find -delete.
+func TestIntegrationApkCacheCleanupFindDelete(t *testing.T) {
+	src := "FROM alpine\nRUN apk add curl && find /var/cache/apk -type f -delete\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewApkCacheCleanup()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationApkCacheCleanupNil ensures nil documents handled.
+func TestIntegrationApkCacheCleanupNil(t *testing.T) {
+	r := NewApkCacheCleanup()
+	if findings, err := r.Check(context.Background(), nil); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", findings, err)
+	}
+	if findings, err := r.Check(context.Background(), &ir.Document{}); err != nil || len(findings) != 0 {
+		t.Fatalf("expected no findings on empty doc: %v %v", findings, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add DL3047 rule to ensure APK cache is cleaned or avoided
- document and test APK cache cleanup guidance

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689eb83940ac83328ead3f2c5277ecd4