### PR TITLE
Add DL3048 rule for invalid Docker label keys

### DIFF
--- a/docs/rules/DL3048.md
+++ b/docs/rules/DL3048.md
@@ -1,0 +1,3 @@
+# DL3048 - Invalid Label Key
+
+Label keys must use lower-case a–z, 0–9, '.' and '-' only, avoid reserved namespaces, and cannot have leading/trailing or repeated separators.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -25,6 +25,7 @@ The following Hadolint-compatible rules are implemented:
 
 - [DL3041](DL3041.md) - Avoid dnf upgrade or update in Dockerfiles.
 - [DL3042](DL3042.md) - Combine consecutive RUN instructions that use the same package manager.
+- [DL3048](DL3048.md) - Invalid Label Key
 - [DL3060](DL3060.md) - `yarn cache clean` missing after `yarn install`.
 
 

--- a/internal/rules/DL3048.go
+++ b/internal/rules/DL3048.go
@@ -1,0 +1,90 @@
+package rules
+
+/*
+ * file: internal/rules/DL3048.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+var reservedLabelNS = regexp.MustCompile(`^(?:com|io)\.docker\.|^org\.dockerproject\.`)
+
+// labelKeyValid ensures LABEL keys follow Docker recommendations and avoid reserved namespaces.
+type labelKeyValid struct{}
+
+// NewLabelKeyValid constructs the rule.
+func NewLabelKeyValid() engine.Rule { return labelKeyValid{} }
+
+// ID returns the rule identifier.
+func (labelKeyValid) ID() string { return "DL3048" }
+
+// Check validates label keys for reserved namespaces and allowed characters.
+func (labelKeyValid) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
+	var findings []engine.Finding
+	if d == nil || d.AST == nil {
+		return findings, nil
+	}
+	for _, n := range d.AST.Children {
+		switch {
+		case strings.EqualFold(n.Value, "label"):
+			findings = append(findings, validateLabelNode(n, n)...)
+		case strings.EqualFold(n.Value, "onbuild") && n.Next != nil:
+			for _, c := range n.Next.Children {
+				if strings.EqualFold(c.Value, "label") {
+					findings = append(findings, validateLabelNode(c, n)...)
+				}
+			}
+		}
+	}
+	return findings, nil
+}
+
+// validateLabelNode reports invalid label keys from the given LABEL node.
+func validateLabelNode(ln *parser.Node, lineNode *parser.Node) []engine.Finding {
+	var findings []engine.Finding
+	for _, p := range collectLabelPairs(ln) {
+		if invalidLabelKey(p.Key) {
+			findings = append(findings, engine.Finding{
+				RuleID:  "DL3048",
+				Message: "Label key `" + p.Key + "` is invalid. Use lower-case a–z, 0–9, '.' and '-' only; avoid reserved namespaces; no leading/trailing or repeated separators.",
+				Line:    lineNode.StartLine,
+			})
+		}
+	}
+	return findings
+}
+
+// invalidLabelKey reports whether the key violates format restrictions or reserved namespaces.
+func invalidLabelKey(key string) bool {
+	if reservedLabelNS.MatchString(key) {
+		return true
+	}
+	if key == "" {
+		return true
+	}
+	if key[0] == '-' || key[0] == '.' || key[len(key)-1] == '-' || key[len(key)-1] == '.' {
+		return true
+	}
+	if strings.Contains(key, "..") || strings.Contains(key, "--") {
+		return true
+	}
+	for _, r := range key {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9':
+		case r == '.' || r == '-':
+		default:
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rules/DL3048_test.go
+++ b/internal/rules/DL3048_test.go
@@ -1,0 +1,86 @@
+// file: internal/rules/DL3048_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+func TestLabelKeyValidID(t *testing.T) {
+	if NewLabelKeyValid().ID() != "DL3048" {
+		t.Fatalf("unexpected id")
+	}
+}
+
+func TestLabelKeyValidViolation(t *testing.T) {
+	src := "FROM scratch\nLABEL com.docker.foo=bar invalid$key=x valid-label=yes\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewLabelKeyValid()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("expected two findings, got %d", len(findings))
+	}
+}
+
+func TestLabelKeyValidOnbuild(t *testing.T) {
+	src := "FROM scratch\nONBUILD LABEL some_key=value\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewLabelKeyValid()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+}
+
+func TestLabelKeyValidClean(t *testing.T) {
+	src := "FROM scratch\nLABEL org.example.meta.build=2025-08-14\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := NewLabelKeyValid()
+	findings, err := r.Check(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+func TestLabelKeyValidNilDocument(t *testing.T) {
+	r := NewLabelKeyValid()
+	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
+		t.Fatalf("expected no findings on nil doc: %v %v", f, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add DL3048 to flag reserved or malformed label keys, including ONBUILD LABEL instructions
- document DL3048 and list it in lint rule catalog
- test label key validation for normal and ONBUILD instructions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689eb8cf955c8332b6f8fdfbbd2d1005