### PR TITLE
Add stage digest pinning rule DL3055

### DIFF
--- a/docs/rules/DL3055.md
+++ b/docs/rules/DL3055.md
@@ -1,3 +1,5 @@
-# DL3055 - Label is not a valid git hash
+# DL3055 - Stage image is not pinned by digest
 
-Labels storing git revisions must be 7 or 40 hexadecimal characters.
+Ensure configured build stages use images pinned by digest using
+`@sha256:<digest>` to guarantee reproducible builds.
+


### PR DESCRIPTION
## Summary
- enforce digest pinning for configured build stages (DL3055)
- document DL3055 stage digest requirement
- add tests for digest-pinned stage images

## Testing
- `go test ./internal/rules -run StageDigestPinned -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689eba7b38ec833299f9a31b19c7d717