### PR TITLE
feat: add colored output to docker-lint

### DIFF
--- a/cmd/docker-lint/color_test.go
+++ b/cmd/docker-lint/color_test.go
@@ -1,0 +1,70 @@
+// file: cmd/docker-lint/color_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package main
+
+import (
+        "bytes"
+        "fmt"
+        "strings"
+        "testing"
+
+        "github.com/sam-caldwell/ansi"
+)
+
+// TestRunColoredWarnings verifies that warnings are printed in yellow when color is enabled.
+func TestRunColoredWarnings(t *testing.T) {
+        df := testDataPath("Dockerfile.bad")
+        var out bytes.Buffer
+        var errBuf bytes.Buffer
+        if err := run([]string{df}, &out, &errBuf, true); err != nil {
+                t.Fatalf("run failed: %v", err)
+        }
+        if !strings.Contains(errBuf.String(), ansi.CodeFgYellow) {
+                t.Fatalf("expected yellow output, got %q", errBuf.String())
+        }
+}
+
+// TestRunColoredSuccess verifies that success messages are printed in green when color is enabled.
+func TestRunColoredSuccess(t *testing.T) {
+        df := testDataPath("Dockerfile.good")
+        var out bytes.Buffer
+        var errBuf bytes.Buffer
+        if err := run([]string{df}, &out, &errBuf, true); err != nil {
+                t.Fatalf("run failed: %v", err)
+        }
+        if !strings.Contains(errBuf.String(), ansi.CodeFgGreen) {
+                t.Fatalf("expected green output, got %q", errBuf.String())
+        }
+}
+
+// TestRunNoColor verifies that color codes are absent when color is disabled.
+func TestRunNoColor(t *testing.T) {
+        df := testDataPath("Dockerfile.bad")
+        var out bytes.Buffer
+        var errBuf bytes.Buffer
+        if err := run([]string{df}, &out, &errBuf, false); err != nil {
+                t.Fatalf("run failed: %v", err)
+        }
+        if strings.Contains(errBuf.String(), ansi.CodeFgYellow) || strings.Contains(errBuf.String(), ansi.CodeFgGreen) {
+                t.Fatalf("unexpected color codes in output: %q", errBuf.String())
+        }
+}
+
+// TestPrintErrorColor verifies that errors are printed in red when color is enabled.
+func TestPrintErrorColor(t *testing.T) {
+        var errBuf bytes.Buffer
+        printError(&errBuf, true, fmt.Errorf("boom"))
+        if !strings.Contains(errBuf.String(), ansi.CodeFgRed) {
+                t.Fatalf("expected red output, got %q", errBuf.String())
+        }
+}
+
+// TestPrintErrorNoColor verifies that errors are not colorized when color is disabled.
+func TestPrintErrorNoColor(t *testing.T) {
+        var errBuf bytes.Buffer
+        printError(&errBuf, false, fmt.Errorf("boom"))
+        if strings.Contains(errBuf.String(), ansi.CodeFgRed) {
+                t.Fatalf("unexpected color codes in output: %q", errBuf.String())
+        }
+}
+

--- a/cmd/docker-lint/main_integration_test.go
+++ b/cmd/docker-lint/main_integration_test.go
@@ -3,23 +3,24 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
-	"errors"
-	"io/fs"
-	"os"
-	"path/filepath"
-	"strings"
-	"testing"
+        "bytes"
+        "encoding/json"
+        "errors"
+        "io"
+        "io/fs"
+        "os"
+        "path/filepath"
+        "strings"
+        "testing"
 
-	"github.com/asymmetric-effort/docker-lint/internal/engine"
-	"github.com/asymmetric-effort/docker-lint/internal/rules"
+        "github.com/asymmetric-effort/docker-lint/internal/engine"
+        "github.com/asymmetric-effort/docker-lint/internal/rules"
 )
 
 func TestIntegrationRunDetectsLatest(t *testing.T) {
 	df := testDataPath("Dockerfile.bad")
-	var out bytes.Buffer
-	if err := run([]string{df}, &out); err != nil {
+        var out bytes.Buffer
+        if err := run([]string{df}, &out, io.Discard, false); err != nil {
 		t.Fatalf("run failed: %v", err)
 	}
 	var findings []engine.Finding
@@ -43,8 +44,8 @@ func TestIntegrationRunDetectsLatest(t *testing.T) {
 
 func TestIntegrationRunClean(t *testing.T) {
 	df := testDataPath("Dockerfile.good")
-	var out bytes.Buffer
-	if err := run([]string{df}, &out); err != nil {
+        var out bytes.Buffer
+        if err := run([]string{df}, &out, io.Discard, false); err != nil {
 		t.Fatalf("run failed: %v", err)
 	}
 	var findings []engine.Finding
@@ -58,8 +59,8 @@ func TestIntegrationRunClean(t *testing.T) {
 
 // TestIntegrationRunNoArgs verifies that run returns a usage error when invoked with no arguments.
 func TestIntegrationRunNoArgs(t *testing.T) {
-	var out bytes.Buffer
-	err := run([]string{}, &out)
+        var out bytes.Buffer
+        err := run([]string{}, &out, io.Discard, false)
 	if err == nil || !strings.Contains(err.Error(), "usage") {
 		t.Fatalf("expected usage error, got %v", err)
 	}
@@ -67,8 +68,8 @@ func TestIntegrationRunNoArgs(t *testing.T) {
 
 // TestIntegrationRunHelpShort verifies that run prints usage when the -h flag is provided.
 func TestIntegrationRunHelpShort(t *testing.T) {
-	var out bytes.Buffer
-	if err := run([]string{"-h"}, &out); err != nil {
+        var out bytes.Buffer
+        if err := run([]string{"-h"}, &out, io.Discard, false); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if !strings.Contains(out.String(), "usage: docker-lint") {
@@ -78,8 +79,8 @@ func TestIntegrationRunHelpShort(t *testing.T) {
 
 // TestIntegrationRunHelpLong verifies that run prints usage when the --help flag is provided.
 func TestIntegrationRunHelpLong(t *testing.T) {
-	var out bytes.Buffer
-	if err := run([]string{"--help"}, &out); err != nil {
+        var out bytes.Buffer
+        if err := run([]string{"--help"}, &out, io.Discard, false); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if !strings.Contains(out.String(), "usage: docker-lint") {
@@ -89,8 +90,8 @@ func TestIntegrationRunHelpLong(t *testing.T) {
 
 // TestIntegrationRunMissingFile verifies that run returns an error when the Dockerfile is missing.
 func TestIntegrationRunMissingFile(t *testing.T) {
-	var out bytes.Buffer
-	err := run([]string{"does-not-exist"}, &out)
+        var out bytes.Buffer
+        err := run([]string{"does-not-exist"}, &out, io.Discard, false)
 	if err == nil || !errors.Is(err, fs.ErrNotExist) {
 		t.Fatalf("expected file not found error, got %v", err)
 	}
@@ -99,8 +100,8 @@ func TestIntegrationRunMissingFile(t *testing.T) {
 // TestIntegrationRunInvalidDockerfile verifies that run returns an error for an invalid Dockerfile.
 func TestIntegrationRunInvalidDockerfile(t *testing.T) {
 	df := testDataPath("Dockerfile.invalid")
-	var out bytes.Buffer
-	if err := run([]string{df}, &out); err == nil {
+        var out bytes.Buffer
+        if err := run([]string{df}, &out, io.Discard, false); err == nil {
 		t.Fatalf("expected parse error, got nil")
 	}
 }
@@ -130,8 +131,8 @@ func TestIntegrationRunGlob(t *testing.T) {
 	}
 
 	pattern := filepath.Join(tmp, "Dockerfile.*")
-	var out bytes.Buffer
-	if err := run([]string{pattern}, &out); err != nil {
+        var out bytes.Buffer
+        if err := run([]string{pattern}, &out, io.Discard, false); err != nil {
 		t.Fatalf("run failed: %v", err)
 	}
 	var findings []engine.Finding
@@ -167,8 +168,8 @@ func TestIntegrationRunDoubleStar(t *testing.T) {
 	}
 
 	pattern := filepath.Join(tmp, "**", "Dockerfile.bad")
-	var out bytes.Buffer
-	if err := run([]string{pattern}, &out); err != nil {
+        var out bytes.Buffer
+        if err := run([]string{pattern}, &out, io.Discard, false); err != nil {
 		t.Fatalf("run failed: %v", err)
 	}
 	var findings []engine.Finding

--- a/cmd/docker-lint/main_test.go
+++ b/cmd/docker-lint/main_test.go
@@ -3,12 +3,14 @@
 package main
 
 import (
-	"encoding/json"
-	"io"
-	"os"
-	"testing"
+        "encoding/json"
+        "io"
+        "os"
+        "strings"
+        "testing"
 
-	"github.com/asymmetric-effort/docker-lint/internal/engine"
+        "github.com/asymmetric-effort/docker-lint/internal/engine"
+        "github.com/sam-caldwell/ansi"
 )
 
 func TestIntegrationMain(t *testing.T) {
@@ -36,4 +38,27 @@ func TestIntegrationMain(t *testing.T) {
 	if len(findings) == 0 {
 		t.Fatalf("expected findings")
 	}
+}
+
+// TestMainNoColorFlag verifies that the --no-color flag disables colored output.
+func TestMainNoColorFlag(t *testing.T) {
+        oldArgs := os.Args
+        defer func() { os.Args = oldArgs }()
+        os.Args = []string{"docker-lint", "--no-color", testDataPath("Dockerfile.good")}
+
+        oldStderr := os.Stderr
+        r, w, err := os.Pipe()
+        if err != nil {
+                t.Fatalf("pipe: %v", err)
+        }
+        os.Stderr = w
+
+        main()
+
+        w.Close()
+        os.Stderr = oldStderr
+        out, _ := io.ReadAll(r)
+        if strings.Contains(string(out), ansi.CodeFgGreen) {
+                t.Fatalf("unexpected color codes in stderr: %q", out)
+        }
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.9.1
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/moby/buildkit v0.23.2
+	github.com/sam-caldwell/ansi v1.0.3
 )
 
 require (
@@ -13,5 +14,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/sam-caldwell/exit v1.0.3 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,10 @@ github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgm
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sam-caldwell/ansi v1.0.3 h1:Nzfn400fd6vbejbffrZfxhyINAX78jN4GT1aJtY6kTI=
+github.com/sam-caldwell/ansi v1.0.3/go.mod h1:R553t3P2UM/FpxUF0IRWQNsfa3F7L6RYkWoOdpco8Tg=
+github.com/sam-caldwell/exit v1.0.3 h1:ibQc6nvE81OZdhxRVwC76451ybRG3f7xC0mrTnzhd80=
+github.com/sam-caldwell/exit v1.0.3/go.mod h1:gy6m0KCj1RZ+KafgZVahgAxdwVm9pud/6O+lZz0NpFw=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
## Summary
- add ANSI-colored summaries for lint results
- support `--no-color` to disable colored output
- cover colorized output and flag handling with tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689ebd7362c88332b2c962a4feb11770