### PR TITLE
test: expand integration label rule coverage

### DIFF
--- a/internal/rules/DL3048_test.go
+++ b/internal/rules/DL3048_test.go
@@ -3,22 +3,24 @@
 package rules
 
 import (
-	"context"
-	"strings"
-	"testing"
+        "context"
+        "strings"
+        "testing"
 
-	"github.com/moby/buildkit/frontend/dockerfile/parser"
+        "github.com/moby/buildkit/frontend/dockerfile/parser"
 
-	"github.com/asymmetric-effort/docker-lint/internal/ir"
+        "github.com/asymmetric-effort/docker-lint/internal/ir"
 )
 
-func TestLabelKeyValidID(t *testing.T) {
-	if NewLabelKeyValid().ID() != "DL3048" {
-		t.Fatalf("unexpected id")
-	}
+// TestIntegrationLabelKeyValidID validates rule identity.
+func TestIntegrationLabelKeyValidID(t *testing.T) {
+        if NewLabelKeyValid().ID() != "DL3048" {
+                t.Fatalf("unexpected id")
+        }
 }
 
-func TestLabelKeyValidViolation(t *testing.T) {
+// TestIntegrationLabelKeyValidViolation reports invalid label keys.
+func TestIntegrationLabelKeyValidViolation(t *testing.T) {
 	src := "FROM scratch\nLABEL com.docker.foo=bar invalid$key=x valid-label=yes\n"
 	res, err := parser.Parse(strings.NewReader(src))
 	if err != nil {
@@ -33,12 +35,13 @@ func TestLabelKeyValidViolation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("check failed: %v", err)
 	}
-	if len(findings) != 2 {
-		t.Fatalf("expected two findings, got %d", len(findings))
-	}
+        if len(findings) != 2 {
+                t.Fatalf("expected two findings, got %d", len(findings))
+        }
 }
 
-func TestLabelKeyValidOnbuild(t *testing.T) {
+// TestIntegrationLabelKeyValidOnbuild detects issues in ONBUILD LABEL instructions.
+func TestIntegrationLabelKeyValidOnbuild(t *testing.T) {
 	src := "FROM scratch\nONBUILD LABEL some_key=value\n"
 	res, err := parser.Parse(strings.NewReader(src))
 	if err != nil {
@@ -53,12 +56,13 @@ func TestLabelKeyValidOnbuild(t *testing.T) {
 	if err != nil {
 		t.Fatalf("check failed: %v", err)
 	}
-	if len(findings) != 1 {
-		t.Fatalf("expected one finding, got %d", len(findings))
-	}
+        if len(findings) != 1 {
+                t.Fatalf("expected one finding, got %d", len(findings))
+        }
 }
 
-func TestLabelKeyValidClean(t *testing.T) {
+// TestIntegrationLabelKeyValidClean ensures compliant Dockerfiles pass.
+func TestIntegrationLabelKeyValidClean(t *testing.T) {
 	src := "FROM scratch\nLABEL org.example.meta.build=2025-08-14\n"
 	res, err := parser.Parse(strings.NewReader(src))
 	if err != nil {
@@ -73,12 +77,13 @@ func TestLabelKeyValidClean(t *testing.T) {
 	if err != nil {
 		t.Fatalf("check failed: %v", err)
 	}
-	if len(findings) != 0 {
-		t.Fatalf("expected no findings, got %d", len(findings))
-	}
+        if len(findings) != 0 {
+                t.Fatalf("expected no findings, got %d", len(findings))
+        }
 }
 
-func TestLabelKeyValidNilDocument(t *testing.T) {
+// TestIntegrationLabelKeyValidNilDocument ensures nil documents are handled gracefully.
+func TestIntegrationLabelKeyValidNilDocument(t *testing.T) {
 	r := NewLabelKeyValid()
 	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
 		t.Fatalf("expected no findings on nil doc: %v %v", f, err)

--- a/internal/rules/DL3050_test.go
+++ b/internal/rules/DL3050_test.go
@@ -3,22 +3,24 @@
 package rules
 
 import (
-	"context"
-	"strings"
-	"testing"
+        "context"
+        "strings"
+        "testing"
 
-	"github.com/moby/buildkit/frontend/dockerfile/parser"
+        "github.com/moby/buildkit/frontend/dockerfile/parser"
 
-	"github.com/asymmetric-effort/docker-lint/internal/ir"
+        "github.com/asymmetric-effort/docker-lint/internal/ir"
 )
 
-func TestSuperfluousLabelsID(t *testing.T) {
-	if NewSuperfluousLabels(nil, true).ID() != "DL3050" {
-		t.Fatalf("unexpected id")
-	}
+// TestIntegrationSuperfluousLabelsID validates rule identity.
+func TestIntegrationSuperfluousLabelsID(t *testing.T) {
+        if NewSuperfluousLabels(nil, true).ID() != "DL3050" {
+                t.Fatalf("unexpected id")
+        }
 }
 
-func TestSuperfluousLabelsViolation(t *testing.T) {
+// TestIntegrationSuperfluousLabelsViolation reports unknown labels in strict mode.
+func TestIntegrationSuperfluousLabelsViolation(t *testing.T) {
 	src := "FROM scratch\nLABEL unknown=1\n"
 	res, err := parser.Parse(strings.NewReader(src))
 	if err != nil {
@@ -34,12 +36,13 @@ func TestSuperfluousLabelsViolation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("check failed: %v", err)
 	}
-	if len(findings) != 1 {
-		t.Fatalf("expected one finding, got %d", len(findings))
-	}
+        if len(findings) != 1 {
+                t.Fatalf("expected one finding, got %d", len(findings))
+        }
 }
 
-func TestSuperfluousLabelsClean(t *testing.T) {
+// TestIntegrationSuperfluousLabelsClean ensures known labels pass in strict mode.
+func TestIntegrationSuperfluousLabelsClean(t *testing.T) {
 	src := "FROM scratch\nLABEL known=1\n"
 	res, err := parser.Parse(strings.NewReader(src))
 	if err != nil {
@@ -55,12 +58,13 @@ func TestSuperfluousLabelsClean(t *testing.T) {
 	if err != nil {
 		t.Fatalf("check failed: %v", err)
 	}
-	if len(findings) != 0 {
-		t.Fatalf("expected no findings, got %d", len(findings))
-	}
+        if len(findings) != 0 {
+                t.Fatalf("expected no findings, got %d", len(findings))
+        }
 }
 
-func TestSuperfluousLabelsNonStrict(t *testing.T) {
+// TestIntegrationSuperfluousLabelsNonStrict allows unknown labels in non-strict mode.
+func TestIntegrationSuperfluousLabelsNonStrict(t *testing.T) {
 	src := "FROM scratch\nLABEL unknown=1\n"
 	res, err := parser.Parse(strings.NewReader(src))
 	if err != nil {
@@ -75,12 +79,13 @@ func TestSuperfluousLabelsNonStrict(t *testing.T) {
 	if err != nil {
 		t.Fatalf("check failed: %v", err)
 	}
-	if len(findings) != 0 {
-		t.Fatalf("expected no findings, got %d", len(findings))
-	}
+        if len(findings) != 0 {
+                t.Fatalf("expected no findings, got %d", len(findings))
+        }
 }
 
-func TestSuperfluousLabelsNilDocument(t *testing.T) {
+// TestIntegrationSuperfluousLabelsNilDocument ensures nil documents are handled gracefully.
+func TestIntegrationSuperfluousLabelsNilDocument(t *testing.T) {
 	r := NewSuperfluousLabels(nil, true)
 	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
 		t.Fatalf("expected no findings on nil doc: %v %v", f, err)

--- a/internal/rules/DL3051_test.go
+++ b/internal/rules/DL3051_test.go
@@ -3,22 +3,24 @@
 package rules
 
 import (
-	"context"
-	"strings"
-	"testing"
+        "context"
+        "strings"
+        "testing"
 
-	"github.com/moby/buildkit/frontend/dockerfile/parser"
+        "github.com/moby/buildkit/frontend/dockerfile/parser"
 
-	"github.com/asymmetric-effort/docker-lint/internal/ir"
+        "github.com/asymmetric-effort/docker-lint/internal/ir"
 )
 
-func TestLabelNotEmptyID(t *testing.T) {
-	if NewLabelNotEmpty(nil).ID() != "DL3051" {
-		t.Fatalf("unexpected id")
-	}
+// TestIntegrationLabelNotEmptyID validates rule identity.
+func TestIntegrationLabelNotEmptyID(t *testing.T) {
+        if NewLabelNotEmpty(nil).ID() != "DL3051" {
+                t.Fatalf("unexpected id")
+        }
 }
 
-func TestLabelNotEmptyViolation(t *testing.T) {
+// TestIntegrationLabelNotEmptyViolation detects empty label values.
+func TestIntegrationLabelNotEmptyViolation(t *testing.T) {
 	src := "FROM scratch\nLABEL foo=\"\"\n"
 	res, err := parser.Parse(strings.NewReader(src))
 	if err != nil {
@@ -34,12 +36,13 @@ func TestLabelNotEmptyViolation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("check failed: %v", err)
 	}
-	if len(findings) != 1 {
-		t.Fatalf("expected one finding, got %d", len(findings))
-	}
+        if len(findings) != 1 {
+                t.Fatalf("expected one finding, got %d", len(findings))
+        }
 }
 
-func TestLabelNotEmptyClean(t *testing.T) {
+// TestIntegrationLabelNotEmptyClean ensures populated values pass.
+func TestIntegrationLabelNotEmptyClean(t *testing.T) {
 	src := "FROM scratch\nLABEL foo=bar\n"
 	res, err := parser.Parse(strings.NewReader(src))
 	if err != nil {
@@ -55,12 +58,13 @@ func TestLabelNotEmptyClean(t *testing.T) {
 	if err != nil {
 		t.Fatalf("check failed: %v", err)
 	}
-	if len(findings) != 0 {
-		t.Fatalf("expected no findings, got %d", len(findings))
-	}
+        if len(findings) != 0 {
+                t.Fatalf("expected no findings, got %d", len(findings))
+        }
 }
 
-func TestLabelNotEmptyWhitespace(t *testing.T) {
+// TestIntegrationLabelNotEmptyWhitespace flags values containing only whitespace.
+func TestIntegrationLabelNotEmptyWhitespace(t *testing.T) {
 	src := "FROM scratch\nLABEL foo=\" \"\n"
 	res, err := parser.Parse(strings.NewReader(src))
 	if err != nil {
@@ -76,12 +80,13 @@ func TestLabelNotEmptyWhitespace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("check failed: %v", err)
 	}
-	if len(findings) != 1 {
-		t.Fatalf("expected one finding, got %d", len(findings))
-	}
+        if len(findings) != 1 {
+                t.Fatalf("expected one finding, got %d", len(findings))
+        }
 }
 
-func TestLabelNotEmptyOverwrite(t *testing.T) {
+// TestIntegrationLabelNotEmptyOverwrite verifies later non-empty labels override earlier empty ones.
+func TestIntegrationLabelNotEmptyOverwrite(t *testing.T) {
 	src := "FROM scratch\nLABEL foo=\"\"\nLABEL foo=\"bar\"\n"
 	res, err := parser.Parse(strings.NewReader(src))
 	if err != nil {
@@ -114,12 +119,13 @@ func TestLabelNotEmptyOverwrite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("check failed: %v", err)
 	}
-	if len(findings) != 1 {
-		t.Fatalf("expected one finding, got %d", len(findings))
-	}
+        if len(findings) != 1 {
+                t.Fatalf("expected one finding, got %d", len(findings))
+        }
 }
 
-func TestLabelNotEmptyNilDocument(t *testing.T) {
+// TestIntegrationLabelNotEmptyNilDocument ensures nil documents are handled gracefully.
+func TestIntegrationLabelNotEmptyNilDocument(t *testing.T) {
 	r := NewLabelNotEmpty(nil)
 	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
 		t.Fatalf("expected no findings on nil doc: %v %v", f, err)

--- a/internal/rules/DL3052_test.go
+++ b/internal/rules/DL3052_test.go
@@ -3,22 +3,24 @@
 package rules
 
 import (
-	"context"
-	"strings"
-	"testing"
+        "context"
+        "strings"
+        "testing"
 
-	"github.com/moby/buildkit/frontend/dockerfile/parser"
+        "github.com/moby/buildkit/frontend/dockerfile/parser"
 
-	"github.com/asymmetric-effort/docker-lint/internal/ir"
+        "github.com/asymmetric-effort/docker-lint/internal/ir"
 )
 
-func TestLabelURLValidID(t *testing.T) {
-	if NewLabelURLValid(nil).ID() != "DL3052" {
-		t.Fatalf("unexpected id")
-	}
+// TestIntegrationLabelURLValidID validates rule identity.
+func TestIntegrationLabelURLValidID(t *testing.T) {
+        if NewLabelURLValid(nil).ID() != "DL3052" {
+                t.Fatalf("unexpected id")
+        }
 }
 
-func TestLabelURLValidViolation(t *testing.T) {
+// TestIntegrationLabelURLValidViolation detects malformed URLs.
+func TestIntegrationLabelURLValidViolation(t *testing.T) {
 	src := "FROM scratch\nLABEL homepage=not-a-url\n"
 	res, err := parser.Parse(strings.NewReader(src))
 	if err != nil {
@@ -34,12 +36,13 @@ func TestLabelURLValidViolation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("check failed: %v", err)
 	}
-	if len(findings) != 1 {
-		t.Fatalf("expected one finding, got %d", len(findings))
-	}
+        if len(findings) != 1 {
+                t.Fatalf("expected one finding, got %d", len(findings))
+        }
 }
 
-func TestLabelURLValidClean(t *testing.T) {
+// TestIntegrationLabelURLValidClean ensures valid URLs pass.
+func TestIntegrationLabelURLValidClean(t *testing.T) {
 	src := "FROM scratch\nLABEL homepage=http://example.com\n"
 	res, err := parser.Parse(strings.NewReader(src))
 	if err != nil {
@@ -55,12 +58,13 @@ func TestLabelURLValidClean(t *testing.T) {
 	if err != nil {
 		t.Fatalf("check failed: %v", err)
 	}
-	if len(findings) != 0 {
-		t.Fatalf("expected no findings, got %d", len(findings))
-	}
+        if len(findings) != 0 {
+                t.Fatalf("expected no findings, got %d", len(findings))
+        }
 }
 
-func TestLabelURLValidNilDocument(t *testing.T) {
+// TestIntegrationLabelURLValidNilDocument ensures nil documents are handled gracefully.
+func TestIntegrationLabelURLValidNilDocument(t *testing.T) {
 	r := NewLabelURLValid(nil)
 	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
 		t.Fatalf("expected no findings on nil doc: %v %v", f, err)

--- a/internal/rules/DL3053_test.go
+++ b/internal/rules/DL3053_test.go
@@ -3,22 +3,24 @@
 package rules
 
 import (
-	"context"
-	"strings"
-	"testing"
+        "context"
+        "strings"
+        "testing"
 
-	"github.com/moby/buildkit/frontend/dockerfile/parser"
+        "github.com/moby/buildkit/frontend/dockerfile/parser"
 
-	"github.com/asymmetric-effort/docker-lint/internal/ir"
+        "github.com/asymmetric-effort/docker-lint/internal/ir"
 )
 
-func TestLabelTimeRFC3339ID(t *testing.T) {
-	if NewLabelTimeRFC3339(nil).ID() != "DL3053" {
-		t.Fatalf("unexpected id")
-	}
+// TestIntegrationLabelTimeRFC3339ID validates rule identity.
+func TestIntegrationLabelTimeRFC3339ID(t *testing.T) {
+        if NewLabelTimeRFC3339(nil).ID() != "DL3053" {
+                t.Fatalf("unexpected id")
+        }
 }
 
-func TestLabelTimeRFC3339Violation(t *testing.T) {
+// TestIntegrationLabelTimeRFC3339Violation detects non-RFC3339 timestamps.
+func TestIntegrationLabelTimeRFC3339Violation(t *testing.T) {
 	src := "FROM scratch\nLABEL built=not-time\n"
 	res, err := parser.Parse(strings.NewReader(src))
 	if err != nil {
@@ -34,12 +36,13 @@ func TestLabelTimeRFC3339Violation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("check failed: %v", err)
 	}
-	if len(findings) != 1 {
-		t.Fatalf("expected one finding, got %d", len(findings))
-	}
+        if len(findings) != 1 {
+                t.Fatalf("expected one finding, got %d", len(findings))
+        }
 }
 
-func TestLabelTimeRFC3339Clean(t *testing.T) {
+// TestIntegrationLabelTimeRFC3339Clean ensures valid timestamps pass.
+func TestIntegrationLabelTimeRFC3339Clean(t *testing.T) {
 	src := "FROM scratch\nLABEL built=2025-01-01T00:00:00Z\n"
 	res, err := parser.Parse(strings.NewReader(src))
 	if err != nil {
@@ -55,12 +58,13 @@ func TestLabelTimeRFC3339Clean(t *testing.T) {
 	if err != nil {
 		t.Fatalf("check failed: %v", err)
 	}
-	if len(findings) != 0 {
-		t.Fatalf("expected no findings, got %d", len(findings))
-	}
+        if len(findings) != 0 {
+                t.Fatalf("expected no findings, got %d", len(findings))
+        }
 }
 
-func TestLabelTimeRFC3339NilDocument(t *testing.T) {
+// TestIntegrationLabelTimeRFC3339NilDocument ensures nil documents are handled gracefully.
+func TestIntegrationLabelTimeRFC3339NilDocument(t *testing.T) {
 	r := NewLabelTimeRFC3339(nil)
 	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
 		t.Fatalf("expected no findings on nil doc: %v %v", f, err)

--- a/internal/rules/DL3054_test.go
+++ b/internal/rules/DL3054_test.go
@@ -3,22 +3,24 @@
 package rules
 
 import (
-	"context"
-	"strings"
-	"testing"
+        "context"
+        "strings"
+        "testing"
 
-	"github.com/moby/buildkit/frontend/dockerfile/parser"
+        "github.com/moby/buildkit/frontend/dockerfile/parser"
 
-	"github.com/asymmetric-effort/docker-lint/internal/ir"
+        "github.com/asymmetric-effort/docker-lint/internal/ir"
 )
 
-func TestLabelSPDXValidID(t *testing.T) {
-	if NewLabelSPDXValid(nil).ID() != "DL3054" {
-		t.Fatalf("unexpected id")
-	}
+// TestIntegrationLabelSPDXValidID validates rule identity.
+func TestIntegrationLabelSPDXValidID(t *testing.T) {
+        if NewLabelSPDXValid(nil).ID() != "DL3054" {
+                t.Fatalf("unexpected id")
+        }
 }
 
-func TestLabelSPDXValidViolation(t *testing.T) {
+// TestIntegrationLabelSPDXValidViolation detects invalid SPDX license identifiers.
+func TestIntegrationLabelSPDXValidViolation(t *testing.T) {
 	src := "FROM scratch\nLABEL license=not@spdx\n"
 	res, err := parser.Parse(strings.NewReader(src))
 	if err != nil {
@@ -34,12 +36,13 @@ func TestLabelSPDXValidViolation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("check failed: %v", err)
 	}
-	if len(findings) != 1 {
-		t.Fatalf("expected one finding, got %d", len(findings))
-	}
+        if len(findings) != 1 {
+                t.Fatalf("expected one finding, got %d", len(findings))
+        }
 }
 
-func TestLabelSPDXValidClean(t *testing.T) {
+// TestIntegrationLabelSPDXValidClean ensures valid SPDX identifiers pass.
+func TestIntegrationLabelSPDXValidClean(t *testing.T) {
 	src := "FROM scratch\nLABEL license=MIT\n"
 	res, err := parser.Parse(strings.NewReader(src))
 	if err != nil {
@@ -55,12 +58,13 @@ func TestLabelSPDXValidClean(t *testing.T) {
 	if err != nil {
 		t.Fatalf("check failed: %v", err)
 	}
-	if len(findings) != 0 {
-		t.Fatalf("expected no findings, got %d", len(findings))
-	}
+        if len(findings) != 0 {
+                t.Fatalf("expected no findings, got %d", len(findings))
+        }
 }
 
-func TestLabelSPDXValidNilDocument(t *testing.T) {
+// TestIntegrationLabelSPDXValidNilDocument ensures nil documents are handled gracefully.
+func TestIntegrationLabelSPDXValidNilDocument(t *testing.T) {
 	r := NewLabelSPDXValid(nil)
 	if f, err := r.Check(context.Background(), nil); err != nil || len(f) != 0 {
 		t.Fatalf("expected no findings on nil doc: %v %v", f, err)


### PR DESCRIPTION
## Summary
- run label validation rule tests as part of integration suite
- document label rule tests and ensure they execute during coverage runs

## Testing
- `go test ./... -short -cover`
- `go test ./... -run Integration -covermode=atomic -coverpkg=./... -coverprofile=coverage.out`
- `go tool cover -func=coverage.out | awk '/total:/ { print; if ($3+0 < 80) exit 1 }'`


------
https://chatgpt.com/codex/tasks/task_b_689ebe9abee4833297bc570868f3a029