### PR TITLE
Fix staticcheck warnings in CLI and pip rule

### DIFF
--- a/cmd/docker-lint/main.go
+++ b/cmd/docker-lint/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -49,7 +50,7 @@ func main() {
 // When color is true, the summary uses ANSI colors.
 func run(args []string, out io.Writer, errOut io.Writer, color bool) error {
 	if len(args) < 1 {
-		return fmt.Errorf(usageText)
+		return errors.New(usageText)
 	}
 	if args[0] == "-h" || args[0] == "--help" {
 		printUsage(out)

--- a/internal/rules/DL3013.go
+++ b/internal/rules/DL3013.go
@@ -98,11 +98,9 @@ func violatesPipPin(cmd []string) bool {
 			case "r", "requirement":
 				requirement = true
 				i++
-				break
 			case "c", "constraint":
 				hasConstraint = true
 				i++
-				break
 			default:
 				if _, ok := flagsWithArg[flag]; ok {
 					i++


### PR DESCRIPTION
## Summary
- replace fmt.Errorf usage with errors.New for usage text
- remove redundant break statements in pip pinning rule

## Testing
- `go test ./...`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_b_689ec1eb8c9c833293bd313998bee604