### PR TITLE
feat: support inline rule exclusions

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -39,13 +39,19 @@ func (r *Registry) Register(rule Rule) { r.rules = append(r.rules, rule) }
 
 // Run executes all registered rules against the document.
 func (r *Registry) Run(ctx context.Context, d *ir.Document) ([]Finding, error) {
+	ignores := lineIgnores(d)
 	var all []Finding
 	for _, rl := range r.rules {
 		f, err := rl.Check(ctx, d)
 		if err != nil {
 			return nil, err
 		}
-		all = append(all, f...)
+		for _, fd := range f {
+			if shouldSkip(ignores, fd) {
+				continue
+			}
+			all = append(all, fd)
+		}
 	}
 	return all, nil
 }

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1,31 +1,36 @@
 // file: internal/engine/engine_test.go
 // (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
-package engine
+package engine_test
 
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	engine "github.com/asymmetric-effort/docker-lint/internal/engine"
 	"github.com/asymmetric-effort/docker-lint/internal/ir"
+	"github.com/asymmetric-effort/docker-lint/internal/rules"
 )
 
 type stubRule struct {
 	id       string
-	findings []Finding
+	findings []engine.Finding
 	err      error
 }
 
 func (s stubRule) ID() string { return s.id }
 
-func (s stubRule) Check(ctx context.Context, d *ir.Document) ([]Finding, error) {
+func (s stubRule) Check(ctx context.Context, d *ir.Document) ([]engine.Finding, error) {
 	return s.findings, s.err
 }
 
 // TestIntegrationRegistryRun verifies successful rule execution.
 func TestIntegrationRegistryRun(t *testing.T) {
-	r := NewRegistry()
-	r.Register(stubRule{id: "A", findings: []Finding{{RuleID: "A"}}})
+	r := engine.NewRegistry()
+	r.Register(stubRule{id: "A", findings: []engine.Finding{{RuleID: "A"}}})
 	out, err := r.Run(context.Background(), &ir.Document{})
 	if err != nil {
 		t.Fatalf("run failed: %v", err)
@@ -37,9 +42,53 @@ func TestIntegrationRegistryRun(t *testing.T) {
 
 // TestIntegrationRegistryRunError ensures errors propagate from rules.
 func TestIntegrationRegistryRunError(t *testing.T) {
-	r := NewRegistry()
+	r := engine.NewRegistry()
 	r.Register(stubRule{id: "A", err: errors.New("bad")})
 	if _, err := r.Run(context.Background(), &ir.Document{}); err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+// TestIntegrationInlineIgnorePrevLine ensures preceding ignore pragmas skip rules.
+func TestIntegrationInlineIgnorePrevLine(t *testing.T) {
+	src := "# hadolint ignore=DL3007\nFROM alpine\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := engine.NewRegistry()
+	r.Register(rules.NewNoLatestTag())
+	findings, err := r.Run(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// TestIntegrationInlineIgnoreSameLine ensures trailing ignore pragmas skip rules.
+func TestIntegrationInlineIgnoreSameLine(t *testing.T) {
+	src := "FROM alpine # hadolint ignore=DL3007\n"
+	res, err := parser.Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	doc, err := ir.BuildDocument("Dockerfile", res.AST)
+	if err != nil {
+		t.Fatalf("build document: %v", err)
+	}
+	r := engine.NewRegistry()
+	r.Register(rules.NewNoLatestTag())
+	findings, err := r.Run(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
 	}
 }

--- a/internal/engine/ignore.go
+++ b/internal/engine/ignore.go
@@ -1,0 +1,74 @@
+package engine
+
+/*
+ * file: internal/engine/ignore.go
+ * (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+ */
+
+import (
+	"strings"
+
+	"github.com/asymmetric-effort/docker-lint/internal/ir"
+)
+
+// lineIgnores returns rule IDs to skip keyed by line number.
+//
+// lineIgnores scans the document's AST for `hadolint ignore=` pragmas and
+// records which rules should be skipped for each instruction line.
+func lineIgnores(d *ir.Document) map[int]map[string]struct{} {
+	m := make(map[int]map[string]struct{})
+	if d == nil || d.AST == nil {
+		return m
+	}
+	for _, n := range d.AST.Children {
+		line := n.StartLine
+		for _, com := range n.PrevComment {
+			addIgnores(m, line, parseIgnorePragma(com))
+		}
+		addIgnores(m, line, parseIgnorePragma(n.Original))
+	}
+	return m
+}
+
+// addIgnores merges rule IDs into the map for a given line.
+func addIgnores(m map[int]map[string]struct{}, line int, ids []string) {
+	if len(ids) == 0 {
+		return
+	}
+	set, ok := m[line]
+	if !ok {
+		set = make(map[string]struct{})
+		m[line] = set
+	}
+	for _, id := range ids {
+		set[strings.ToUpper(id)] = struct{}{}
+	}
+}
+
+// parseIgnorePragma extracts rule IDs from a comment or instruction.
+func parseIgnorePragma(s string) []string {
+	idx := strings.Index(strings.ToLower(s), "hadolint ignore=")
+	if idx == -1 {
+		return nil
+	}
+	rest := s[idx+len("hadolint ignore="):]
+	rest = strings.TrimSpace(rest)
+	fields := strings.FieldsFunc(rest, func(r rune) bool { return r == ',' || r == ' ' || r == '\t' })
+	var ids []string
+	for _, f := range fields {
+		if trimmed := strings.TrimSpace(f); trimmed != "" {
+			ids = append(ids, trimmed)
+		}
+	}
+	return ids
+}
+
+// shouldSkip reports whether the finding should be skipped based on ignore pragmas.
+func shouldSkip(ignores map[int]map[string]struct{}, f Finding) bool {
+	ids, ok := ignores[f.Line]
+	if !ok {
+		return false
+	}
+	_, skip := ids[strings.ToUpper(f.RuleID)]
+	return skip
+}


### PR DESCRIPTION
## Summary
- skip lint findings when matching `hadolint ignore=` pragmas are present
- parse Dockerfile comments for inline rule exclusions
- test engine behavior for preceding and trailing ignore pragmas

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689ec31c952c8332b96228f1a2643b47