### PR TITLE
Fix configuration exclusion handling

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,16 +3,18 @@
 package config
 
 import (
+	"gopkg.in/yaml.v3"
 	"os"
 	"path/filepath"
-	"gopkg.in/yaml.v3"
 )
 
 // Config represents docker-lint configuration settings.
 //
-// Exclusions lists rule IDs that should be skipped during linting.
+// Exclusions lists rule IDs that should be skipped globally during linting.
+// Exclude maps filenames to rule IDs that should be skipped for specific files.
 type Config struct {
-	Exclusions []string `yaml:"exclusions"`
+	Exclusions []string            `yaml:"exclusions"`
+	Exclude    map[string][]string `yaml:"exclude"`
 }
 
 // Load reads the configuration from the given YAML file path.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -25,6 +25,9 @@ func TestLoad(t *testing.T) {
 	}
 	if cfg.Exclusions[0] != "DL3007" || cfg.Exclusions[1] != "DL3043" {
 		t.Fatalf("unexpected exclusions: %v", cfg.Exclusions)
+	}
+}
+
 // TestLoadAndIsRuleExcluded verifies configuration loading and exclusion checks.
 func TestLoadAndIsRuleExcluded(t *testing.T) {
 	tmp := t.TempDir()


### PR DESCRIPTION
## Summary
- add per-file exclusion mapping to config and method
- repair configuration tests
- simplify CLI config loading and error handling

## Testing
- `go vet ./...`
- `staticcheck ./...`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_689ec6c1f53c83329ae56b0dccefa6b6