### PR TITLE
feat: adopt hadolint-compatible config format

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,16 @@ Example output:
 
 ## Configuration
 
-docker-lint reads an optional `.docker-lint.yaml` from the current working directory to configure file-based rule exclusions.
+docker-lint reads an optional `.docker-lint.yaml` from the current working directory. The file uses the same format as
+`hadolint` and allows global rule ignores and other settings.
 
 ```yaml
-exclude:
-  Dockerfile.dev:
-    - DL3007
+ignored:
+  - DL3007
+failure-threshold: warning
 ```
 
-The above disables rule `DL3007` for `Dockerfile.dev`.
+The above disables rule `DL3007` and sets the failure threshold to `warning`.
 
 ## Linting Containers
 

--- a/cmd/docker-lint/main_integration_test.go
+++ b/cmd/docker-lint/main_integration_test.go
@@ -181,8 +181,8 @@ func TestIntegrationRunDoubleStar(t *testing.T) {
 	}
 }
 
-// TestIntegrationRunDefaultConfigExclusions verifies that .docker-lint.yaml exclusions are applied.
-func TestIntegrationRunDefaultConfigExclusions(t *testing.T) {
+// TestIntegrationRunDefaultConfigIgnored verifies that .docker-lint.yaml ignored rules are applied.
+func TestIntegrationRunDefaultConfigIgnored(t *testing.T) {
 	tmp := t.TempDir()
 	// write Dockerfile
 	src := testDataPath("Dockerfile.bad")
@@ -195,7 +195,7 @@ func TestIntegrationRunDefaultConfigExclusions(t *testing.T) {
 		t.Fatalf("write dockerfile: %v", err)
 	}
 	// write config
-	cfg := []byte("exclusions:\n  - DL3007\n")
+	cfg := []byte("ignored:\n  - DL3007\n")
 	if err := os.WriteFile(filepath.Join(tmp, ".docker-lint.yaml"), cfg, 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -216,7 +216,7 @@ func TestIntegrationRunDefaultConfigExclusions(t *testing.T) {
 	}
 }
 
-// TestIntegrationRunConfigFlagShort verifies that -c config flag applies exclusions.
+// TestIntegrationRunConfigFlagShort verifies that -c config flag applies ignored rules.
 func TestIntegrationRunConfigFlagShort(t *testing.T) {
 	tmp := t.TempDir()
 	src := testDataPath("Dockerfile.bad")
@@ -229,7 +229,7 @@ func TestIntegrationRunConfigFlagShort(t *testing.T) {
 		t.Fatalf("write dockerfile: %v", err)
 	}
 	cfgPath := filepath.Join(tmp, "cfg.yaml")
-	cfg := []byte("exclusions:\n  - DL3007\n")
+	cfg := []byte("ignored:\n  - DL3007\n")
 	if err := os.WriteFile(cfgPath, cfg, 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -249,7 +249,7 @@ func TestIntegrationRunConfigFlagShort(t *testing.T) {
 	}
 }
 
-// TestIntegrationRunConfigFlagLong verifies that --config flag applies exclusions.
+// TestIntegrationRunConfigFlagLong verifies that --config flag applies ignored rules.
 func TestIntegrationRunConfigFlagLong(t *testing.T) {
 	tmp := t.TempDir()
 	src := testDataPath("Dockerfile.bad")
@@ -262,7 +262,7 @@ func TestIntegrationRunConfigFlagLong(t *testing.T) {
 		t.Fatalf("write dockerfile: %v", err)
 	}
 	cfgPath := filepath.Join(tmp, "cfg.yaml")
-	cfg := []byte("exclusions:\n  - DL3007\n")
+	cfg := []byte("ignored:\n  - DL3007\n")
 	if err := os.WriteFile(cfgPath, cfg, 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,35 @@
+# Configuration
+
+Docker-lint accepts configuration files in the same format as [hadolint](https://github.com/hadolint/hadolint). Place a
+`.docker-lint.yaml` file in the project root to adjust rule behavior.
+
+## Example
+
+```yaml
+ignored:
+  - DL3006
+  - DL3008
+  - DL3026
+  - DL3050
+  - SC3050
+  - SC3020
+override:
+  warning:
+    - SC1099
+failure-threshold: warning
+trustedRegistries:
+  - ghcr.io
+strict-labels: true
+label-schema:
+  author: text
+  base-image: text
+  contact: text
+  created: text
+  documentation: text
+  git-commit: text
+  license: text
+  version: text
+```
+
+See the [hadolint documentation](https://github.com/hadolint/hadolint#configure) for the meaning of these fields. Docker-lint
+currently honours the `ignored` list and parses the remaining fields for forward compatibility.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,15 +4,33 @@ package config
 
 import (
 	"os"
-	"path/filepath"
+
 	"gopkg.in/yaml.v3"
 )
 
 // Config represents docker-lint configuration settings.
 //
-// Exclusions lists rule IDs that should be skipped during linting.
+// The structure matches the configuration options used by hadolint so that
+// users can reuse existing `.hadolint.yaml` files. Only a subset of hadolint's
+// options are currently consumed by docker-lint.
 type Config struct {
-	Exclusions []string `yaml:"exclusions"`
+	// Ignored lists rule IDs that should be skipped globally during linting.
+	Ignored []string `yaml:"ignored"`
+
+	// Override remaps rule IDs to a severity level, keyed by that level.
+	Override map[string][]string `yaml:"override"`
+
+	// FailureThreshold defines the minimum severity that causes a failure.
+	FailureThreshold string `yaml:"failure-threshold"`
+
+	// TrustedRegistries specifies registries considered secure for FROM instructions.
+	TrustedRegistries []string `yaml:"trustedRegistries"`
+
+	// StrictLabels toggles enforcement of a configured label schema.
+	StrictLabels bool `yaml:"strict-labels"`
+
+	// LabelSchema maps required label keys to a description or type.
+	LabelSchema map[string]string `yaml:"label-schema"`
 }
 
 // Load reads the configuration from the given YAML file path.
@@ -28,17 +46,12 @@ func Load(path string) (*Config, error) {
 	return &cfg, nil
 }
 
-// IsRuleExcluded reports whether the given rule is excluded for the file.
-func (c *Config) IsRuleExcluded(path, rule string) bool {
+// IsIgnored reports whether the given rule ID is globally ignored.
+func (c *Config) IsIgnored(rule string) bool {
 	if c == nil {
 		return false
 	}
-	base := filepath.Base(path)
-	rules, ok := c.Exclude[base]
-	if !ok {
-		return false
-	}
-	for _, r := range rules {
+	for _, r := range c.Ignored {
 		if r == rule {
 			return true
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,39 +8,56 @@ import (
 	"testing"
 )
 
-// TestLoad verifies that Load reads exclusions from a YAML file.
+// TestLoad verifies that Load parses hadolint-style configuration files.
 func TestLoad(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "cfg.yaml")
-	data := []byte("exclusions:\n  - DL3007\n  - DL3043\n")
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	src := []byte("" +
+		"ignored:\n" +
+		"  - DL3007\n" +
+		"override:\n" +
+		"  warning:\n" +
+		"    - SC1099\n" +
+		"failure-threshold: warning\n" +
+		"trustedRegistries:\n" +
+		"  - ghcr.io\n" +
+		"strict-labels: true\n" +
+		"label-schema:\n" +
+		"  author: text\n")
+	if err := os.WriteFile(path, src, 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 	cfg, err := Load(path)
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	if len(cfg.Exclusions) != 2 {
-		t.Fatalf("expected 2 exclusions, got %d", len(cfg.Exclusions))
+	if len(cfg.Ignored) != 1 || cfg.Ignored[0] != "DL3007" {
+		t.Fatalf("unexpected ignored: %v", cfg.Ignored)
 	}
-	if cfg.Exclusions[0] != "DL3007" || cfg.Exclusions[1] != "DL3043" {
-		t.Fatalf("unexpected exclusions: %v", cfg.Exclusions)
-// TestLoadAndIsRuleExcluded verifies configuration loading and exclusion checks.
-func TestLoadAndIsRuleExcluded(t *testing.T) {
-	tmp := t.TempDir()
-	cfgPath := filepath.Join(tmp, ".docker-lint.yaml")
-	src := "exclude:\n  Dockerfile.bad:\n    - DL3007\n"
-	if err := os.WriteFile(cfgPath, []byte(src), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
+	if cfg.FailureThreshold != "warning" {
+		t.Fatalf("unexpected failure threshold: %s", cfg.FailureThreshold)
 	}
-	cfg, err := Load(cfgPath)
-	if err != nil {
-		t.Fatalf("load: %v", err)
+	if !cfg.StrictLabels {
+		t.Fatalf("expected strict labels enabled")
 	}
-	if !cfg.IsRuleExcluded(filepath.Join(tmp, "Dockerfile.bad"), "DL3007") {
-		t.Fatalf("expected rule excluded")
+	if v := cfg.LabelSchema["author"]; v != "text" {
+		t.Fatalf("unexpected label schema: %v", cfg.LabelSchema)
 	}
-	if cfg.IsRuleExcluded(filepath.Join(tmp, "Dockerfile.bad"), "DL3043") {
-		t.Fatalf("unexpected exclusion")
+	if r := cfg.Override["warning"]; len(r) != 1 || r[0] != "SC1099" {
+		t.Fatalf("unexpected override: %v", cfg.Override)
+	}
+	if len(cfg.TrustedRegistries) != 1 || cfg.TrustedRegistries[0] != "ghcr.io" {
+		t.Fatalf("unexpected registries: %v", cfg.TrustedRegistries)
+	}
+}
+
+// TestIsIgnored verifies that IsIgnored returns true for configured rules.
+func TestIsIgnored(t *testing.T) {
+	cfg := Config{Ignored: []string{"DL3007"}}
+	if !cfg.IsIgnored("DL3007") {
+		t.Fatalf("expected rule ignored")
+	}
+	if cfg.IsIgnored("DL3043") {
+		t.Fatalf("unexpected ignore")
 	}
 }


### PR DESCRIPTION
## Summary
- support hadolint-style `.docker-lint.yaml` with `ignored`, `override`, and other fields
- honor `ignored` rules during linting
- document configuration options

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689ec7e3eda4833293f96bdba89461e8