### PR TITLE
chore(ci): run staticcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,11 @@ jobs:
         run: go mod tidy
       - name: Check formatting
         run: test -z "$(gofmt -l .)"
-      - name: Vet
-        run: go vet ./...
+      - name: Lint
+        run: |
+          go vet ./...
+          command -v staticcheck || go install honnef.co/go/tools/cmd/staticcheck@latest
+          staticcheck ./...
       - name: Unit tests
         run: go test ./... -short -cover
       - name: Integration tests


### PR DESCRIPTION
## Summary
- run `go vet` and `staticcheck` in CI lint step

## Testing
- `go vet ./...`
- `command -v staticcheck || go install honnef.co/go/tools/cmd/staticcheck@latest`
- `staticcheck ./...`
- `go test ./... -short -cover`
- `go test ./... -run Integration -covermode=atomic -coverpkg=./... -coverprofile=coverage.out`
- `go tool cover -func=coverage.out | awk '/total:/ { print; if ($3+0 < 80) exit 1 }'`

------
https://chatgpt.com/codex/tasks/task_b_689ec8d09d788332948b1319043ecf9b