### PR TITLE
docs: expand specs for DL3040 and DL3050

### DIFF
--- a/docs/rules/DL3040.md
+++ b/docs/rules/DL3040.md
@@ -1,2 +1,40 @@
 # DL3040 - dnf clean all missing after dnf command
-Run `dnf clean all` (or remove `/var/cache/dnf`) in the same `RUN` after `dnf` or `microdnf` package operations to avoid leaving cache.
+
+## Purpose
+Prevent leftover `dnf` or `microdnf` metadata from inflating image size.
+
+## Scope
+Applies to any `RUN` instruction invoking `dnf` or `microdnf`.
+
+## Rule Statement (normative)
+Emit **DL3040** when a `RUN` instruction performs a modifying `dnf`/`microdnf` operation and does not clean the package cache in the same instruction.
+
+**Message:** `dnf clean all missing after dnf command.`
+
+## Rationale
+Package managers leave metadata in `/var/cache/dnf` after install or update operations. Removing it keeps layers small and reproducible.
+
+## Detection Logic (high-level)
+1. Split each `RUN` command into segments.
+2. Track the last modifying `dnf`/`microdnf` segment (`install`, `upgrade`, `update`, `groupinstall`, `groupupdate`, `distrosync`, `autoremove`, `remove`).
+3. Track cleanup segments that follow (`dnf clean all`, `microdnf clean all`, `rm -rf /var/cache/dnf`, or `find /var/cache/dnf -delete`).
+4. Report DL3040 when the last cleanup occurs before the last modifying operation or is absent.
+
+## Severity
+`info`
+
+## Examples
+### Non-compliant
+```Dockerfile
+RUN dnf install -y jq
+```
+
+### Compliant
+```Dockerfile
+RUN dnf install -y jq && dnf clean all
+```
+
+### Compliant (rm cleanup)
+```Dockerfile
+RUN microdnf install -y jq && rm -rf /var/cache/dnf
+```

--- a/docs/rules/DL3050.md
+++ b/docs/rules/DL3050.md
@@ -1,3 +1,38 @@
 # DL3050 - Superfluous label(s) present
 
-When strict label validation is enabled, each `LABEL` key must appear in the configured label schema. Any label key not whitelisted triggers this rule.
+## Purpose
+Ensure images only carry labels defined in the expected schema when strict validation is enabled.
+
+## Scope
+Evaluates every `LABEL` instruction when a label schema is configured and strict mode is active.
+
+## Rule Statement (normative)
+Emit **DL3050** when a `LABEL` instruction includes a key not present in the configured label schema while strict mode is enabled.
+
+**Message:** `Superfluous label(s) present.`
+
+## Rationale
+Restricting labels to a known set prevents typos and unauthorized metadata from entering images.
+
+## Configuration
+Provide a label schema and enable strict validation. Without strict mode, this rule is silent.
+
+## Detection Logic (high-level)
+1. If strict mode is disabled, no findings are produced.
+2. For each `LABEL` instruction, extract key/value pairs.
+3. Report DL3050 if any key is absent from the schema (one finding per instruction).
+
+## Severity
+`info`
+
+## Examples
+### Non-compliant
+Schema: `{ "org.opencontainers.image.source": string }`
+```Dockerfile
+LABEL org.opencontainers.image.revision="abcd1234"
+```
+
+### Compliant
+```Dockerfile
+LABEL org.opencontainers.image.source="https://github.com/acme/project"
+```


### PR DESCRIPTION
## Summary
- document required cache cleanup after dnf/microdnf operations
- clarify label schema enforcement for superfluous labels in strict mode

## Testing
- `go test ./...` *(fails: internal/config/config_test.go:29:6: expected '(')*

------
https://chatgpt.com/codex/tasks/task_b_689ec8175c948332b1365e60daa4fe65