### PR TITLE
Remove unused filepath import

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,7 +5,6 @@ package config
 import (
 	"gopkg.in/yaml.v3"
 	"os"
-	"path/filepath"
 )
 
 // Config represents docker-lint configuration settings.


### PR DESCRIPTION
## Summary
- remove unused filepath import from configuration loader

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689eca4154a083329d914008260c0024