### PR TITLE
Add sad path tests for config and rule utilities

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,7 +5,6 @@ package config
 import (
 	"gopkg.in/yaml.v3"
 	"os"
-	"path/filepath"
 )
 
 // Config represents docker-lint configuration settings.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -61,3 +61,30 @@ func TestIsIgnored(t *testing.T) {
 		t.Fatalf("unexpected ignore")
 	}
 }
+
+// TestLoadMissingFile ensures Load returns an error when the file is absent.
+func TestLoadMissingFile(t *testing.T) {
+	if _, err := Load("non-existent.yaml"); err == nil {
+		t.Fatalf("expected error for missing file")
+	}
+}
+
+// TestLoadInvalidYAML ensures Load surfaces YAML parsing errors.
+func TestLoadInvalidYAML(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "cfg.yaml")
+	if err := os.WriteFile(path, []byte("::notyaml"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if _, err := Load(path); err == nil {
+		t.Fatalf("expected parse error")
+	}
+}
+
+// TestIsIgnoredNilConfig verifies that a nil Config does not ignore rules.
+func TestIsIgnoredNilConfig(t *testing.T) {
+	var cfg *Config
+	if cfg.IsIgnored("DL3007") {
+		t.Fatalf("expected nil config to not ignore")
+	}
+}

--- a/internal/rules/DL4006_utils_test.go
+++ b/internal/rules/DL4006_utils_test.go
@@ -1,0 +1,68 @@
+// file: internal/rules/DL4006_utils_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+)
+
+// TestIsNonPosixShell exercises detection of non-POSIX shells.
+func TestIsNonPosixShell(t *testing.T) {
+	shells := []string{"pwsh", "powershell"}
+	if isNonPosixShell(nil, shells) {
+		t.Fatalf("nil node should be false")
+	}
+	n := &parser.Node{Next: &parser.Node{Value: "pwsh"}}
+	if !isNonPosixShell(n, shells) {
+		t.Fatalf("expected pwsh to be non-posix")
+	}
+	posix := &parser.Node{Next: &parser.Node{Value: "/bin/bash"}}
+	if isNonPosixShell(posix, shells) {
+		t.Fatalf("unexpected non-posix result")
+	}
+}
+
+// TestHasPipefailOption verifies detection of -o pipefail.
+func TestHasPipefailOption(t *testing.T) {
+	valid := map[string]bool{"/bin/bash": true}
+	if hasPipefailOption(nil, valid) {
+		t.Fatalf("nil node should be false")
+	}
+	n := &parser.Node{Next: &parser.Node{Value: "/bin/bash", Next: &parser.Node{Value: "-o", Next: &parser.Node{Value: "pipefail"}}}}
+	if !hasPipefailOption(n, valid) {
+		t.Fatalf("expected detection of pipefail option")
+	}
+	no := &parser.Node{Next: &parser.Node{Value: "/bin/bash"}}
+	if hasPipefailOption(no, valid) {
+		t.Fatalf("unexpected pipefail detection")
+	}
+	bad := &parser.Node{Next: &parser.Node{Value: "/bin/sh"}}
+	if hasPipefailOption(bad, valid) {
+		t.Fatalf("invalid shell should be false")
+	}
+}
+
+// TestRunHasPipe covers shell and JSON RUN forms.
+func TestRunHasPipe(t *testing.T) {
+	if runHasPipe(nil) {
+		t.Fatalf("nil node should be false")
+	}
+	jsonPipe := &parser.Node{Attributes: map[string]bool{"json": true}, Next: &parser.Node{Value: "echo", Next: &parser.Node{Value: "|"}}}
+	if !runHasPipe(jsonPipe) {
+		t.Fatalf("expected pipe in json form")
+	}
+	jsonNo := &parser.Node{Attributes: map[string]bool{"json": true}, Next: &parser.Node{Value: "echo"}}
+	if runHasPipe(jsonNo) {
+		t.Fatalf("unexpected pipe detection")
+	}
+	shPipe := &parser.Node{Next: &parser.Node{Value: "echo hi | grep h"}}
+	if !runHasPipe(shPipe) {
+		t.Fatalf("expected pipe in shell form")
+	}
+	shNo := &parser.Node{Next: &parser.Node{Value: "echo hi"}}
+	if runHasPipe(shNo) {
+		t.Fatalf("unexpected pipe detection")
+	}
+}

--- a/internal/rules/ruleutil_test.go
+++ b/internal/rules/ruleutil_test.go
@@ -1,0 +1,50 @@
+// file: internal/rules/ruleutil_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+)
+
+// TestSplitRunSegments covers JSON, shell, and error scenarios.
+func TestSplitRunSegments(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		if splitRunSegments(nil) != nil {
+			t.Fatalf("expected nil for nil node")
+		}
+	})
+	t.Run("json", func(t *testing.T) {
+		n := &parser.Node{Attributes: map[string]bool{"json": true}, Next: &parser.Node{Value: "CMD"}}
+		got := splitRunSegments(n)
+		want := [][]string{{"cmd"}}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v want %v", got, want)
+		}
+	})
+	t.Run("shell", func(t *testing.T) {
+		n := &parser.Node{Next: &parser.Node{Value: "echo hi && ls"}}
+		got := splitRunSegments(n)
+		want := [][]string{{"echo", "hi"}, {"ls"}}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v want %v", got, want)
+		}
+	})
+	t.Run("bad shell", func(t *testing.T) {
+		n := &parser.Node{Next: &parser.Node{Value: "echo 'unterminated"}}
+		if splitRunSegments(n) != nil {
+			t.Fatalf("expected nil on parse error")
+		}
+	})
+}
+
+// TestLowerSlice ensures lowerSlice returns a lowercase copy.
+func TestLowerSlice(t *testing.T) {
+	got := lowerSlice([]string{"A", "b"})
+	want := []string{"a", "b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}

--- a/internal/rules/run_commands_test.go
+++ b/internal/rules/run_commands_test.go
@@ -1,0 +1,60 @@
+// file: internal/rules/run_commands_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+)
+
+// TestExtractCommands exercises extractCommands across JSON and shell forms.
+func TestExtractCommands(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		if extractCommands(nil) != nil {
+			t.Fatalf("expected nil for nil node")
+		}
+	})
+	t.Run("json", func(t *testing.T) {
+		n := &parser.Node{Attributes: map[string]bool{"json": true}, Next: &parser.Node{Value: "CMD"}}
+		got := extractCommands(n)
+		want := []string{"cmd"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v want %v", got, want)
+		}
+	})
+	t.Run("shell", func(t *testing.T) {
+		n := &parser.Node{Next: &parser.Node{Value: "echo hi && ls"}}
+		got := extractCommands(n)
+		want := []string{"echo", "ls"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v want %v", got, want)
+		}
+	})
+	t.Run("bad shell", func(t *testing.T) {
+		n := &parser.Node{Next: &parser.Node{Value: "echo 'unterminated"}}
+		if extractCommands(n) != nil {
+			t.Fatalf("expected nil on parse error")
+		}
+	})
+}
+
+// TestCommandNames verifies command extraction with shell connectors.
+func TestCommandNames(t *testing.T) {
+	tokens := []string{"echo", "hi", "&&", "ls", "||", "cat", "|", "grep", ";", "sed"}
+	want := []string{"echo", "ls", "cat", "grep", "sed"}
+	if got := commandNames(tokens); !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+// TestLowerSegments confirms all segments are lowercased.
+func TestLowerSegments(t *testing.T) {
+	segs := [][]string{{"Echo", "Hi"}, {"LS"}}
+	got := lowerSegments(segs)
+	want := [][]string{{"echo", "hi"}, {"ls"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- remove stray import from configuration loader
- test configuration loading error conditions
- cover rule utilities and pipefail helpers with unit tests

## Testing
- `go test ./internal/config -cover`
- `go test ./... -coverprofile=coverage.out`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_b_689ec9f585408332a174eabe36a0476c