### PR TITLE
docs: expand DL3038 specification

### DIFF
--- a/docs/rules/DL3038.md
+++ b/docs/rules/DL3038.md
@@ -1,3 +1,18 @@
 # DL3038 - Use -y with dnf install
 
-Ensure `dnf` or `microdnf` install commands include the `-y` or `--assumeyes` flag to avoid interactive prompts.
+## Description
+`dnf` or `microdnf` install commands should run non-interactively. Missing the `-y` or `--assumeyes` flag can halt builds waiting for user input.
+
+## Goals
+- Guarantee package installations using dnf complete without manual confirmation.
+- Prevent stalled builds and ensure reproducible Docker images.
+
+## Specification
+1. Iterate over every `RUN` instruction in the Dockerfile.
+2. Split the instruction into shell command segments.
+3. For each segment:
+   - If the first token is `dnf` or `microdnf` and any subsequent token is `install`, `groupinstall`, or `localinstall`, verify the presence of one of:
+     - `-y`
+     - `--assumeyes`
+     - `--assumeyes=<value>`
+4. If the required flag is missing, emit `DL3038` pointing to the line of the `RUN` instruction with the message: `Use the -y switch to avoid manual input dnf install -y <package>`.


### PR DESCRIPTION
## Summary
- detail DL3038 rule to enforce non-interactive dnf install commands

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689ecb3aa16c8332985bf5029f266e21