### PR TITLE
test: expand coverage and verify rule docs

### DIFF
--- a/cmd/docker-lint/errors_test.go
+++ b/cmd/docker-lint/errors_test.go
@@ -1,0 +1,83 @@
+// file: cmd/docker-lint/errors_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asymmetric-effort/docker-lint/internal/engine"
+)
+
+// TestRunConfigFlagMissingValue verifies that an error is returned when -c lacks a value.
+func TestRunConfigFlagMissingValue(t *testing.T) {
+	var out bytes.Buffer
+	err := run([]string{"-c"}, &out, io.Discard, false)
+	if err == nil || !strings.Contains(err.Error(), "missing config file") {
+		t.Fatalf("expected missing config error, got %v", err)
+	}
+}
+
+// TestRunConfigFileNotFound verifies that a missing config file causes an error.
+func TestRunConfigFileNotFound(t *testing.T) {
+	df := testDataPath("Dockerfile.good")
+	var out bytes.Buffer
+	err := run([]string{"-c", filepath.Join(t.TempDir(), "nope.yaml"), df}, &out, io.Discard, false)
+	if err == nil {
+		t.Fatalf("expected error for missing config file")
+	}
+}
+
+// TestRunInvalidDefaultConfig ensures an invalid .docker-lint.yaml triggers an error.
+func TestRunInvalidDefaultConfig(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, ".docker-lint.yaml")
+	if err := os.WriteFile(cfgPath, []byte("::invalid"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	df := testDataPath("Dockerfile.good")
+	t.Cleanup(func() { os.Remove(cfgPath) })
+	t.Chdir(tmp)
+	var out bytes.Buffer
+	if err := run([]string{df}, &out, io.Discard, false); err == nil {
+		t.Fatalf("expected error for invalid config")
+	}
+}
+
+// TestExpandPathsInvalidPattern verifies that invalid glob patterns return an error.
+func TestExpandPathsInvalidPattern(t *testing.T) {
+	if _, err := expandPaths([]string{"["}); err == nil {
+		t.Fatalf("expected glob error")
+	}
+}
+
+// TestLintFileOpenError verifies that lintFile reports errors when files cannot be opened.
+func TestLintFileOpenError(t *testing.T) {
+	reg := engine.NewRegistry()
+	if _, err := lintFile(context.Background(), reg, "does-not-exist"); err == nil {
+		t.Fatalf("expected open error")
+	}
+}
+
+// TestMainExitOnError ensures main exits with status 1 on failure.
+func TestMainExitOnError(t *testing.T) {
+	if os.Getenv("DOCKER_LINT_CRASHER") == "1" {
+		os.Args = []string{"docker-lint"}
+		main()
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestMainExitOnError")
+	cmd.Env = append(os.Environ(), "DOCKER_LINT_CRASHER=1")
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() == 0 {
+		t.Fatalf("expected exit code 1, got %v", err)
+	}
+}

--- a/internal/rules/DL3013_helpers_test.go
+++ b/internal/rules/DL3013_helpers_test.go
@@ -1,0 +1,76 @@
+// file: internal/rules/DL3013_helpers_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"testing"
+)
+
+// TestSplitRunCommands covers token splitting with connectors.
+func TestSplitRunCommands(t *testing.T) {
+	tokens := []string{"pip", "install", "a", "&&", "pip", "install", "b", ";", "echo", "done"}
+	cmds := splitRunCommands(tokens)
+	if len(cmds) != 3 {
+		t.Fatalf("expected 3 commands, got %d", len(cmds))
+	}
+	if len(cmds[0]) != 3 || len(cmds[1]) != 3 || len(cmds[2]) != 2 {
+		t.Fatalf("unexpected command segments: %#v", cmds)
+	}
+	if c := splitRunCommands([]string{"echo", "hi"}); len(c) != 1 {
+		t.Fatalf("expected single command, got %d", len(c))
+	}
+}
+
+// TestPipInstallIndex exercises pipInstallIndex for various forms.
+func TestPipInstallIndex(t *testing.T) {
+	if idx, ok := pipInstallIndex([]string{"pip", "install", "pkg"}); !ok || idx != 2 {
+		t.Fatalf("expected index 2, got %d %v", idx, ok)
+	}
+	if idx, ok := pipInstallIndex([]string{"python3", "-m", "pip", "install", "pkg"}); !ok || idx != 4 {
+		t.Fatalf("expected index 4, got %d %v", idx, ok)
+	}
+	if _, ok := pipInstallIndex([]string{"pip"}); ok {
+		t.Fatalf("expected not ok for incomplete command")
+	}
+}
+
+// TestPipVersionFixed ensures detection of version pinning.
+func TestPipVersionFixed(t *testing.T) {
+	cases := map[string]bool{
+		"pkg@git+https://repo": true,
+		"pkg==1.0":             true,
+		"pkg>=1.0":             true,
+		"pkg.whl":              true,
+		"pkg.tar.gz":           true,
+		"path/to/pkg":          true,
+		"pkg":                  false,
+	}
+	for pkg, expect := range cases {
+		if got := pipVersionFixed(pkg); got != expect {
+			t.Fatalf("pkg %s expected %v got %v", pkg, expect, got)
+		}
+	}
+}
+
+// TestViolatesPipPin exercises edge cases in version checks.
+func TestViolatesPipPin(t *testing.T) {
+	if violatesPipPin([]string{"pip", "install", "pkg"}) != true {
+		t.Fatalf("expected violation")
+	}
+	if violatesPipPin([]string{"pip", "install", "pkg==1"}) {
+		t.Fatalf("unexpected violation")
+	}
+	if violatesPipPin([]string{"pip", "install", "-r", "req.txt"}) {
+		t.Fatalf("requirement should not violate")
+	}
+	if violatesPipPin([]string{"pip", "install", "--constraint", "c.txt"}) {
+		t.Fatalf("constraint should not violate")
+	}
+	// flag with argument should skip next token
+	if violatesPipPin([]string{"pip", "install", "--index-url", "u", "pkg"}) != true {
+		t.Fatalf("expected violation with flag")
+	}
+	if violatesPipPin([]string{"python", "-m", "pip", "install", "pkg"}) != true {
+		t.Fatalf("expected violation for python -m pip")
+	}
+}

--- a/internal/rules/DL3014_helpers_test.go
+++ b/internal/rules/DL3014_helpers_test.go
@@ -1,0 +1,45 @@
+// file: internal/rules/DL3014_helpers_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestIsAptGetInstall checks apt-get install detection.
+func TestIsAptGetInstall(t *testing.T) {
+	cases := map[string]bool{
+		"apt-get install":    true,
+		"apt-get -y install": true,
+		"apt-get update":     false,
+		"echo":               false,
+	}
+	for cmd, expect := range cases {
+		tokens := strings.Split(cmd, " ")
+		if got := isAptGetInstall(tokens); got != expect {
+			t.Fatalf("%s: expected %v got %v", cmd, expect, got)
+		}
+	}
+}
+
+// TestHasYesOption verifies detection of non-interactive flags.
+func TestHasYesOption(t *testing.T) {
+	cases := map[string]bool{
+		"apt-get install -y":              true,
+		"apt-get install --yes":           true,
+		"apt-get install --assume-yes":    true,
+		"apt-get install -qq":             true,
+		"apt-get install -q=2":            true,
+		"apt-get install --quiet=2":       true,
+		"apt-get install -q -q":           true,
+		"apt-get install --quiet --quiet": true,
+		"apt-get install":                 false,
+	}
+	for cmd, expect := range cases {
+		tokens := strings.Split(cmd, " ")
+		if got := hasYesOption(tokens); got != expect {
+			t.Fatalf("%s: expected %v got %v", cmd, expect, got)
+		}
+	}
+}

--- a/internal/rules/DL3015_helpers_test.go
+++ b/internal/rules/DL3015_helpers_test.go
@@ -1,0 +1,61 @@
+// file: internal/rules/DL3015_helpers_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+)
+
+// TestRunTokens covers JSON and shell forms.
+func TestRunTokens(t *testing.T) {
+	if tokens := runTokens(nil); tokens != nil {
+		t.Fatalf("expected nil tokens for nil node")
+	}
+	n := &parser.Node{Value: "run"}
+	if tokens := runTokens(n); tokens != nil {
+		t.Fatalf("expected nil tokens for missing next")
+	}
+	jsonNode := &parser.Node{Attributes: map[string]bool{"json": true}, Next: &parser.Node{Value: "echo", Next: &parser.Node{Value: "hi"}}}
+	tks := runTokens(jsonNode)
+	if len(tks) != 2 || tks[0] != "echo" || tks[1] != "hi" {
+		t.Fatalf("unexpected tokens: %#v", tks)
+	}
+	shellNode := &parser.Node{Next: &parser.Node{Value: "echo hi"}}
+	tks = runTokens(shellNode)
+	if len(tks) != 2 || tks[0] != "echo" || tks[1] != "hi" {
+		t.Fatalf("unexpected shell tokens: %#v", tks)
+	}
+}
+
+// TestSplitTokens ensures commands are divided at connectors.
+func TestSplitTokens(t *testing.T) {
+	tokens := []string{"apt-get", "update", "&&", "apt-get", "install", "-y"}
+	cmds := splitTokens(tokens)
+	if len(cmds) != 2 {
+		t.Fatalf("expected 2 commands, got %d", len(cmds))
+	}
+	if len(splitTokens([]string{"echo"})) != 1 {
+		t.Fatalf("expected 1 command")
+	}
+}
+
+// TestAptInstallMissingFlag covers flag detection.
+func TestAptInstallMissingFlag(t *testing.T) {
+	if aptInstallMissingFlag([]string{}) {
+		t.Fatalf("empty tokens should not flag")
+	}
+	if aptInstallMissingFlag([]string{"echo"}) {
+		t.Fatalf("non-apt command should not flag")
+	}
+	if !aptInstallMissingFlag([]string{"apt-get", "install"}) {
+		t.Fatalf("missing flag should be reported")
+	}
+	if aptInstallMissingFlag([]string{"apt-get", "install", "--no-install-recommends"}) {
+		t.Fatalf("flag present should not report")
+	}
+	if aptInstallMissingFlag([]string{"apt-get", "install", "-o", "APT::Install-Recommends=false"}) {
+		t.Fatalf("option flag should not report")
+	}
+}

--- a/internal/rules/DL3038_helpers_test.go
+++ b/internal/rules/DL3038_helpers_test.go
@@ -1,0 +1,26 @@
+// file: internal/rules/DL3038_helpers_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestIsDnfInstall verifies detection of install subcommands.
+func TestIsDnfInstall(t *testing.T) {
+	cases := map[string]bool{
+		"dnf install":           true,
+		"dnf groupinstall":      true,
+		"microdnf localinstall": true,
+		"dnf update":            false,
+		"echo hi":               false,
+		"dnf":                   false,
+	}
+	for cmd, expect := range cases {
+		tokens := strings.Split(cmd, " ")
+		if got := isDnfInstall(tokens); got != expect {
+			t.Fatalf("%s: expected %v got %v", cmd, expect, got)
+		}
+	}
+}

--- a/internal/rules/DL3040_helpers_test.go
+++ b/internal/rules/DL3040_helpers_test.go
@@ -1,0 +1,27 @@
+// file: internal/rules/DL3040_helpers_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import "testing"
+
+// TestCleansDnfCache exercises cache cleanup detection.
+func TestCleansDnfCache(t *testing.T) {
+	if !cleansDnfCache([]string{"dnf", "clean", "all"}) {
+		t.Fatalf("expected dnf clean all to be detected")
+	}
+	if !cleansDnfCache([]string{"rm", "-fr", "/var/cache/dnf"}) {
+		t.Fatalf("expected rm -fr to be detected")
+	}
+	if cleansDnfCache([]string{"rm", "/var/cache/dnf"}) {
+		t.Fatalf("missing flags should not detect")
+	}
+	if !cleansDnfCache([]string{"find", "/var/cache/dnf", "-delete"}) {
+		t.Fatalf("expected find -delete detection")
+	}
+	if cleansDnfCache([]string{"find", "/var/cache/dnf", "-print"}) {
+		t.Fatalf("-print should not detect")
+	}
+	if cleansDnfCache([]string{"echo", "hi"}) {
+		t.Fatalf("unrelated command should not detect")
+	}
+}

--- a/internal/rules/DL3041_helpers_test.go
+++ b/internal/rules/DL3041_helpers_test.go
@@ -1,0 +1,27 @@
+// file: internal/rules/DL3041_helpers_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestIsDnfUpgrade verifies detection of disallowed upgrade commands.
+func TestIsDnfUpgrade(t *testing.T) {
+	cases := map[string]bool{
+		"dnf upgrade":      true,
+		"dnf update":       true,
+		"dnf -y upgrade":   true,
+		"microdnf upgrade": true,
+		"dnf install":      false,
+		"echo hi":          false,
+		"dnf -y":           false,
+	}
+	for cmd, expect := range cases {
+		tokens := strings.Split(cmd, " ")
+		if got := isDnfUpgrade(tokens); got != expect {
+			t.Fatalf("%s: expected %v got %v", cmd, expect, got)
+		}
+	}
+}

--- a/internal/rules/DL3042_helpers_test.go
+++ b/internal/rules/DL3042_helpers_test.go
@@ -1,0 +1,30 @@
+// file: internal/rules/DL3042_helpers_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import "testing"
+
+// TestPackageManagerFamily verifies detection of package manager families.
+func TestPackageManagerFamily(t *testing.T) {
+	cases := map[string]struct {
+		seg    []string
+		expect string
+	}{
+		"apt-get":   {[]string{"apt-get", "update"}, "apt"},
+		"apt":       {[]string{"apt", "install"}, "apt"},
+		"apk":       {[]string{"apk", "add"}, "apk"},
+		"dnf":       {[]string{"dnf", "upgrade"}, "dnf"},
+		"microdnf":  {[]string{"microdnf", "clean"}, "dnf"},
+		"yum":       {[]string{"yum", "remove"}, "yum"},
+		"zypper":    {[]string{"zypper", "install"}, "zypper"},
+		"flag-skip": {[]string{"apt-get", "-y", "install"}, "apt"},
+		"unknown":   {[]string{"echo", "hi"}, ""},
+		"short":     {[]string{"apt-get"}, ""},
+		"missing":   {[]string{"apt-get", "-y"}, ""},
+	}
+	for name, tc := range cases {
+		if got := packageManagerFamily(tc.seg); got != tc.expect {
+			t.Fatalf("%s: expected %s got %s", name, tc.expect, got)
+		}
+	}
+}

--- a/internal/rules/DL3043_helpers_test.go
+++ b/internal/rules/DL3043_helpers_test.go
@@ -1,0 +1,38 @@
+// file: internal/rules/DL3043_helpers_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import "testing"
+
+// TestNeedsOSVersionTag exercises edge cases for tag requirements.
+func TestNeedsOSVersionTag(t *testing.T) {
+	cases := map[string]bool{
+		"ubuntu":             true,
+		"ubuntu:latest":      true,
+		"ubuntu:jammy":       true,
+		"ubuntu:22.04":       false,
+		"alpine@sha256:dead": true,
+		"$BASE":              false,
+		"scratch":            false,
+	}
+	for image, expect := range cases {
+		if got := needsOSVersionTag(image); got != expect {
+			t.Fatalf("%s: expected %v got %v", image, expect, got)
+		}
+	}
+}
+
+// TestIsOSImage verifies detection of OS base images.
+func TestIsOSImage(t *testing.T) {
+	cases := map[string]bool{
+		"ubuntu":         true,
+		"library/alpine": true,
+		"ghcr.io/other":  false,
+		"golang":         false,
+	}
+	for image, expect := range cases {
+		if got := isOSImage(image); got != expect {
+			t.Fatalf("%s: expected %v got %v", image, expect, got)
+		}
+	}
+}

--- a/internal/rules/DL3044_helpers_test.go
+++ b/internal/rules/DL3044_helpers_test.go
@@ -1,0 +1,26 @@
+// file: internal/rules/DL3044_helpers_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestHasUnpinnedDnfInstall exercises detection of unpinned installs.
+func TestHasUnpinnedDnfInstall(t *testing.T) {
+	cases := map[string]bool{
+		"dnf install pkg-1":      false,
+		"dnf install pkg":        true,
+		"microdnf install pkg-1": false,
+		"dnf --best install pkg": true,
+		"dnf pkg install":        false,
+		"echo":                   false,
+	}
+	for cmd, expect := range cases {
+		tokens := strings.Split(cmd, " ")
+		if got := hasUnpinnedDnfInstall(tokens); got != expect {
+			t.Fatalf("%s: expected %v got %v", cmd, expect, got)
+		}
+	}
+}

--- a/internal/rules/docs_test.go
+++ b/internal/rules/docs_test.go
@@ -1,0 +1,34 @@
+// file: internal/rules/docs_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"testing"
+)
+
+// TestRuleDocsExist ensures every rule has corresponding documentation.
+func TestRuleDocsExist(t *testing.T) {
+	_, file, _, _ := runtime.Caller(0)
+	root := filepath.Join(filepath.Dir(file), "..", "..")
+	ruleDir := filepath.Join(root, "internal", "rules")
+	docDir := filepath.Join(root, "docs", "rules")
+	entries, err := os.ReadDir(ruleDir)
+	if err != nil {
+		t.Fatalf("read rules: %v", err)
+	}
+	re := regexp.MustCompile(`^DL\d+\.go$`)
+	for _, e := range entries {
+		name := e.Name()
+		if !re.MatchString(name) {
+			continue
+		}
+		doc := filepath.Join(docDir, name[:len(name)-3]+".md")
+		if _, err := os.Stat(doc); err != nil {
+			t.Errorf("missing documentation for %s", name)
+		}
+	}
+}

--- a/internal/rules/stage_utils_test.go
+++ b/internal/rules/stage_utils_test.go
@@ -1,0 +1,37 @@
+// file: internal/rules/stage_utils_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package rules
+
+import (
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+)
+
+// TestCopyFromFlag verifies extraction of the --from flag.
+func TestCopyFromFlag(t *testing.T) {
+	n := &parser.Node{Flags: []string{"--from=builder", "--chown=0"}}
+	v, ok := copyFromFlag(n)
+	if !ok || v != "builder" {
+		t.Fatalf("expected builder, got %q %v", v, ok)
+	}
+	n = &parser.Node{Flags: []string{"--chown=0"}}
+	if _, ok := copyFromFlag(n); ok {
+		t.Fatalf("expected no flag")
+	}
+}
+
+// TestStageAlias verifies detection of stage aliases in FROM instructions.
+func TestStageAlias(t *testing.T) {
+	n := &parser.Node{Value: "from"}
+	n.Next = &parser.Node{Value: "alpine", Next: &parser.Node{Value: "as", Next: &parser.Node{Value: "builder"}}}
+	if a := stageAlias(n); a != "builder" {
+		t.Fatalf("expected builder, got %q", a)
+	}
+	if a := stageAlias(&parser.Node{Value: "from", Next: &parser.Node{Value: "alpine"}}); a != "" {
+		t.Fatalf("expected empty alias, got %q", a)
+	}
+	if a := stageAlias(nil); a != "" {
+		t.Fatalf("expected empty alias for nil input")
+	}
+}


### PR DESCRIPTION
## Summary
- add CLI error-path tests to cover config and glob failures
- enforce docs exist for every implemented rule
- expand rule helper tests to push test coverage past 95%

## Testing
- `go test ./... -coverprofile=coverage.out`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_b_689ecbd83b48833295602971b262cbdb