### PR TITLE
docs: add rule specifications for DL3032-DL3037

### DIFF
--- a/docs/rules/DL3032.md
+++ b/docs/rules/DL3032.md
@@ -1,3 +1,20 @@
 # DL3032 - Run `yum clean all`
 
-After using `yum install`, clear the cache with `yum clean all` or remove `/var/cache/yum/*` in the same layer.
+## Description
+After using `yum` to install packages, the cache should be cleared to prevent
+unnecessary data from persisting in the image layer.
+
+## Goals
+- Minimize image size by removing cached package data.
+- Ensure cache cleanup happens in the same layer as the install.
+
+## Specification
+1. Iterate over every `RUN` instruction in the Dockerfile.
+2. Split each instruction into individual shell command segments.
+3. For each `RUN` instruction:
+   - Detect if any segment performs a `yum` install operation.
+   - Verify that within the same instruction another segment executes either:
+     - `yum clean all`, or
+     - `rm -rf /var/cache/yum/*`.
+4. If a `yum` install occurs without the required cleanup, emit `DL3032` at the
+   line of the `RUN` instruction with the message `` `yum clean all` missing after yum command.``

--- a/docs/rules/DL3033.md
+++ b/docs/rules/DL3033.md
@@ -1,3 +1,22 @@
 # DL3033 - Pin versions in yum install
 
-When using `yum install` or `yum module install`, specify package versions to ensure repeatable builds.
+## Description
+`yum install` and `yum module install` commands should specify explicit package
+or module versions to produce deterministic builds.
+
+## Goals
+- Avoid accidental upgrades when building images.
+- Encourage explicit version pinning for every installed package or module.
+
+## Specification
+1. Iterate over each `RUN` instruction in the Dockerfile and split the
+   instruction into shell command segments.
+2. For every segment starting with `yum`:
+   - If the command uses `module install`, ensure each module argument after
+     `install` contains a colon (`stream:version`).
+   - If the command uses regular `install`, ensure each package argument after
+     `install` includes a hyphenated version (`pkg-version`) or ends with
+     `.rpm`.
+3. Ignore flags beginning with `-` when collecting package names.
+4. If any package or module lacks a version specification, emit `DL3033` at the
+   `RUN` line with the message ``Specify version with `yum install -y <package>-<version>` ``.

--- a/docs/rules/DL3034.md
+++ b/docs/rules/DL3034.md
@@ -1,3 +1,19 @@
 # DL3034 - Use non-interactive zypper
 
-Include `-y`, `-n`, `--no-confirm`, or `--non-interactive` with `zypper` to avoid interactive prompts during builds.
+## Description
+`zypper` commands should run non-interactively to avoid builds waiting for
+confirmation.
+
+## Goals
+- Ensure package operations do not stall the build process.
+- Promote fully automated Docker builds.
+
+## Specification
+1. Iterate over each `RUN` instruction in the Dockerfile and split it into shell
+   command segments.
+2. For every segment beginning with `zypper` followed by one of the actions
+   `install`, `in`, `remove`, `rm`, `source-install`, `si`, or `patch`, check for
+   a non-interactive flag.
+3. Acceptable flags are `-y`, `-n`, `--non-interactive`, or `--no-confirm`.
+4. If the required flag is missing, emit `DL3034` pointing to the `RUN`
+   instruction with the message `Non-interactive switch missing from zypper command: zypper install -y`.

--- a/docs/rules/DL3035.md
+++ b/docs/rules/DL3035.md
@@ -1,3 +1,16 @@
 # DL3035 - Avoid `zypper dist-upgrade`
 
-Using `zypper dist-upgrade` or `zypper dup` is discouraged in Dockerfiles because it upgrades the base image unpredictably.
+## Description
+`zypper dist-upgrade` (or `zypper dup`) can upgrade the base system beyond
+expected versions and should not be used in Docker builds.
+
+## Goals
+- Preserve the stability of the chosen base image.
+- Prevent unexpected package upgrades during the build process.
+
+## Specification
+1. Iterate over each `RUN` instruction and split it into shell command segments.
+2. For every segment beginning with `zypper`, check whether the second token is
+   `dist-upgrade` or `dup`.
+3. If such a segment is found, emit `DL3035` at the line of the `RUN`
+   instruction with the message `Do not use `zypper dist-upgrade`.`

--- a/docs/rules/DL3036.md
+++ b/docs/rules/DL3036.md
@@ -1,3 +1,18 @@
 # DL3036 - Clean zypper cache
 
-After running `zypper install`, clear the package cache with `zypper clean` or `zypper cc` in the same layer.
+## Description
+`zypper` package cache should be cleared after installations to keep images
+small and avoid stale metadata.
+
+## Goals
+- Reduce image size by removing cached data.
+- Ensure cleanup occurs in the same layer as package installation.
+
+## Specification
+1. Iterate over each `RUN` instruction in the Dockerfile and split the
+   instruction into shell command segments.
+2. Determine if any segment executes `zypper install` or `zypper in`.
+3. Within the same `RUN` instruction, check for a segment running `zypper clean`
+   or `zypper cc`.
+4. If a `zypper` install occurs without subsequent cleanup, emit `DL3036` at the
+   `RUN` line with the message `` `zypper clean` missing after zypper use.``

--- a/docs/rules/DL3037.md
+++ b/docs/rules/DL3037.md
@@ -1,3 +1,18 @@
 # DL3037 - Pin versions in zypper install
 
-Specify explicit versions when installing packages with `zypper` to ensure deterministic builds.
+## Description
+`zypper install` commands should pin package versions so the build result is
+reproducible.
+
+## Goals
+- Prevent unintentional upgrades during image builds.
+- Require explicit version specifications for each installed package.
+
+## Specification
+1. Iterate over each `RUN` instruction and split it into shell command segments.
+2. For segments that begin with `zypper install` or `zypper in`:
+   - Collect package arguments excluding flags (tokens beginning with `-`).
+   - Ensure every package argument contains a version indicator (`=`, `>=`, `>`,
+     `<=`, `<`) or ends with `.rpm`.
+3. If any package lacks a version specifier, emit `DL3037` at the line of the
+   `RUN` instruction with the message ``Specify version with `zypper install -y <package>=<version>` ``.


### PR DESCRIPTION
## Summary
- document rule DL3032 to ensure yum installs are followed by cache cleanup
- document rule DL3033 to require version pinning for yum installs
- document rule DL3034 to enforce non-interactive zypper commands
- document rule DL3035 to avoid zypper dist-upgrade
- document rule DL3036 to clean zypper cache after installs
- document rule DL3037 to pin versions in zypper installs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689ecbec43b4833283a99d523a19945d