### PR TITLE
Expose build version via CLI and build metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ test: tidy
 ## Build the docker-lint binary
 build: tidy
 	@mkdir -p build &> /dev/null || true
-	go build -o build/docker-lint -trimpath -ldflags "-s -w" ./cmd/docker-lint
+	VERSION=$$(git describe --tags --always --dirty); \
+        go build -o build/docker-lint -trimpath -ldflags "-s -w -X github.com/asymmetric-effort/docker-lint/internal/version.Current=$${VERSION}" ./cmd/docker-lint
 
 tidy:
 	go mod tidy

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ docker-lint /path/to/Dockerfile
 docker-lint './**/Dockerfile'
 ```
 
+To display the current version:
+
+```bash
+docker-lint --version
+docker-lint -version
+docker-lint version
+```
+
 Example output:
 
 ```json

--- a/cmd/docker-lint/main.go
+++ b/cmd/docker-lint/main.go
@@ -18,10 +18,11 @@ import (
 	"github.com/asymmetric-effort/docker-lint/internal/engine"
 	"github.com/asymmetric-effort/docker-lint/internal/ir"
 	"github.com/asymmetric-effort/docker-lint/internal/rules"
+	"github.com/asymmetric-effort/docker-lint/internal/version"
 )
 
 // usageText describes the command line usage for the application.
-const usageText = "usage: docker-lint [-c file] <Dockerfile>"
+const usageText = "usage: docker-lint [--version] [-c file] <Dockerfile>"
 
 // printUsage writes the CLI usage information to the provided writer.
 func printUsage(out io.Writer) {
@@ -48,7 +49,7 @@ func main() {
 // run executes the linter for the provided arguments and writes JSON findings.
 //
 // In addition to the JSON output, run emits a human-readable summary to errOut.
-// When color is true, the summary uses ANSI colors.
+// When color is true, the summary uses ANSI colors. If args contain a version flag, run prints the application version to out and exits.
 func run(args []string, out io.Writer, errOut io.Writer, color bool) error {
 	var (
 		files      []string
@@ -57,6 +58,9 @@ func run(args []string, out io.Writer, errOut io.Writer, color bool) error {
 	for i := 0; i < len(args); i++ {
 		a := args[i]
 		switch a {
+		case "version", "-version", "--version":
+			fmt.Fprintln(out, version.Current)
+			return nil
 		case "-h", "--help":
 			printUsage(out)
 			return nil

--- a/cmd/docker-lint/main_integration_test.go
+++ b/cmd/docker-lint/main_integration_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/asymmetric-effort/docker-lint/internal/engine"
 	"github.com/asymmetric-effort/docker-lint/internal/rules"
+	"github.com/asymmetric-effort/docker-lint/internal/version"
 )
 
 func TestIntegrationRunDetectsLatest(t *testing.T) {
@@ -279,5 +280,41 @@ func TestIntegrationRunConfigFlagLong(t *testing.T) {
 	}
 	if findings[0].RuleID != rules.NewRequireOSVersionTag().ID() {
 		t.Fatalf("unexpected rule: %s", findings[0].RuleID)
+	}
+}
+
+// TestIntegrationRunVersion ensures the version command prints the current version.
+func TestIntegrationRunVersion(t *testing.T) {
+	var out bytes.Buffer
+	if err := run([]string{"version"}, &out, io.Discard, false); err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	got := strings.TrimSpace(out.String())
+	if got != version.Current {
+		t.Fatalf("expected %q, got %q", version.Current, got)
+	}
+}
+
+// TestIntegrationRunVersionFlagShort ensures -version prints the current version.
+func TestIntegrationRunVersionFlagShort(t *testing.T) {
+	var out bytes.Buffer
+	if err := run([]string{"-version"}, &out, io.Discard, false); err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	got := strings.TrimSpace(out.String())
+	if got != version.Current {
+		t.Fatalf("expected %q, got %q", version.Current, got)
+	}
+}
+
+// TestIntegrationRunVersionFlagLong ensures --version prints the current version.
+func TestIntegrationRunVersionFlagLong(t *testing.T) {
+	var out bytes.Buffer
+	if err := run([]string{"--version"}, &out, io.Discard, false); err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	got := strings.TrimSpace(out.String())
+	if got != version.Current {
+		t.Fatalf("expected %q, got %q", version.Current, got)
 	}
 }

--- a/cmd/docker-lint/main_test.go
+++ b/cmd/docker-lint/main_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/asymmetric-effort/docker-lint/internal/engine"
+	"github.com/asymmetric-effort/docker-lint/internal/version"
 	"github.com/sam-caldwell/ansi"
 )
 
@@ -60,5 +61,77 @@ func TestMainNoColorFlag(t *testing.T) {
 	out, _ := io.ReadAll(r)
 	if strings.Contains(string(out), ansi.CodeFgGreen) {
 		t.Fatalf("unexpected color codes in stderr: %q", out)
+	}
+}
+
+// TestMainVersion ensures the CLI prints the current version with the version command.
+func TestMainVersion(t *testing.T) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"docker-lint", "version"}
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	main()
+
+	w.Close()
+	os.Stdout = oldStdout
+	out, _ := io.ReadAll(r)
+	got := strings.TrimSpace(string(out))
+	if got != version.Current {
+		t.Fatalf("expected %q, got %q", version.Current, got)
+	}
+}
+
+// TestMainVersionFlagShort ensures the CLI prints the version with -version.
+func TestMainVersionFlagShort(t *testing.T) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"docker-lint", "-version"}
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	main()
+
+	w.Close()
+	os.Stdout = oldStdout
+	out, _ := io.ReadAll(r)
+	got := strings.TrimSpace(string(out))
+	if got != version.Current {
+		t.Fatalf("expected %q, got %q", version.Current, got)
+	}
+}
+
+// TestMainVersionFlagLong ensures the CLI prints the version with --version.
+func TestMainVersionFlagLong(t *testing.T) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"docker-lint", "--version"}
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	main()
+
+	w.Close()
+	os.Stdout = oldStdout
+	out, _ := io.ReadAll(r)
+	got := strings.TrimSpace(string(out))
+	if got != version.Current {
+		t.Fatalf("expected %q, got %q", version.Current, got)
 	}
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,8 @@
+// file: internal/version/version.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+// Package version provides application build version information.
+package version
+
+// Current holds the current application version.
+// This value may be overridden at build time using -ldflags.
+var Current = "dev"


### PR DESCRIPTION
## Summary
- add `version` command and flags to print build version
- inject git tag or commit hash during build
- document version usage and test version output

## Testing
- `go vet ./...`
- `staticcheck ./...`
- `go test ./...`
- `make build`


------
https://chatgpt.com/codex/tasks/task_b_689ecc7767ec8332ab5b5accb68335a7