### PR TITLE
Add checks for rule documentation coverage and formatting

### DIFF
--- a/internal/rules/docs_test.go
+++ b/internal/rules/docs_test.go
@@ -3,32 +3,80 @@
 package rules
 
 import (
+	"bufio"
 	"os"
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strings"
 	"testing"
 )
 
-// TestRuleDocsExist ensures every rule has corresponding documentation.
-func TestRuleDocsExist(t *testing.T) {
+// ruleAndDocDirs returns the absolute rule and documentation directories.
+func ruleAndDocDirs(t *testing.T) (string, string) {
+	t.Helper()
 	_, file, _, _ := runtime.Caller(0)
 	root := filepath.Join(filepath.Dir(file), "..", "..")
 	ruleDir := filepath.Join(root, "internal", "rules")
 	docDir := filepath.Join(root, "docs", "rules")
+	return ruleDir, docDir
+}
+
+// TestRuleDocsExist ensures every rule has corresponding documentation.
+func TestRuleDocsExist(t *testing.T) {
+	ruleDir, docDir := ruleAndDocDirs(t)
 	entries, err := os.ReadDir(ruleDir)
 	if err != nil {
 		t.Fatalf("read rules: %v", err)
 	}
-	re := regexp.MustCompile(`^DL\d+\.go$`)
+	re := regexp.MustCompile(`^DL\d{4}\.go$`)
 	for _, e := range entries {
 		name := e.Name()
 		if !re.MatchString(name) {
 			continue
 		}
-		doc := filepath.Join(docDir, name[:len(name)-3]+".md")
+		doc := filepath.Join(docDir, strings.TrimSuffix(name, ".go")+".md")
 		if _, err := os.Stat(doc); err != nil {
 			t.Errorf("missing documentation for %s", name)
+		}
+	}
+}
+
+// TestDocsMatchRules ensures each documentation file corresponds to a rule and
+// starts with the rule identifier.
+func TestDocsMatchRules(t *testing.T) {
+	ruleDir, docDir := ruleAndDocDirs(t)
+	entries, err := os.ReadDir(docDir)
+	if err != nil {
+		t.Fatalf("read docs: %v", err)
+	}
+	re := regexp.MustCompile(`^DL\d{4}\.md$`)
+	for _, e := range entries {
+		name := e.Name()
+		if name == "README.md" || !re.MatchString(name) {
+			continue
+		}
+		rule := filepath.Join(ruleDir, strings.TrimSuffix(name, ".md")+".go")
+		if _, err := os.Stat(rule); err != nil {
+			t.Errorf("documentation exists for missing rule %s", name)
+			continue
+		}
+		path := filepath.Join(docDir, name)
+		f, err := os.Open(path)
+		if err != nil {
+			t.Fatalf("open %s: %v", path, err)
+		}
+		scanner := bufio.NewScanner(f)
+		if !scanner.Scan() {
+			t.Errorf("documentation %s is empty", name)
+			f.Close()
+			continue
+		}
+		title := scanner.Text()
+		f.Close()
+		id := strings.TrimSuffix(name, ".md")
+		if !strings.HasPrefix(title, "# "+id) {
+			t.Errorf("documentation %s has incorrect title %q", name, title)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- ensure each internal rule has corresponding documentation
- verify documentation files only exist for implemented rules and start with rule identifier

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689f1c1c7f608332af061aa9118cafa6