### PR TITLE
docs: add detailed rule specs and verify documentation

### DIFF
--- a/docs/rules/DL4000.md
+++ b/docs/rules/DL4000.md
@@ -1,3 +1,13 @@
 # DL4000 - MAINTAINER is deprecated
 
-The `MAINTAINER` instruction is obsolete. Replace it with a `LABEL maintainer="name"` directive to declare the image author.
+## Description
+The `MAINTAINER` instruction is obsolete. Declare the image author with `LABEL maintainer="name"` instead.
+
+## Goals
+- Remove usage of the deprecated `MAINTAINER` instruction.
+- Promote explicit authorship via a `LABEL` directive.
+
+## Specification
+1. Walk each top-level instruction in the Dockerfile AST.
+2. If an instruction's keyword equals `MAINTAINER` (case-insensitive), emit `DL4000`.
+3. Report the line of the `MAINTAINER` instruction with the message `MAINTAINER is deprecated. Use LABEL maintainer="name" instead.`

--- a/docs/rules/DL4001.md
+++ b/docs/rules/DL4001.md
@@ -1,3 +1,16 @@
 # DL4001 - Either use Wget or Curl but not both
 
+## Description
 Avoid installing or invoking both `curl` and `wget` in the same stage. Choose a single tool to reduce image size and complexity.
+
+## Goals
+- Keep images minimal by selecting a single download utility.
+- Avoid inconsistent behavior from mixing `curl` and `wget`.
+
+## Specification
+1. Iterate through Dockerfile instructions, resetting state on each `FROM`.
+2. For each `RUN` instruction:
+   - Extract individual shell commands.
+   - Detect whether any command starts with `curl` or `wget`.
+3. If a single `RUN` uses both tools or if one tool is used after the other has already appeared in the current stage, emit `DL4001`.
+4. Report the line of the offending `RUN` with the message `Either use Wget or Curl but not both`.

--- a/docs/rules/DL4003.md
+++ b/docs/rules/DL4003.md
@@ -1,3 +1,16 @@
 # DL4003 - Multiple CMD instructions
 
+## Description
 Multiple `CMD` instructions found. If you list more than one `CMD` then only the last `CMD` will take effect.
+
+## Goals
+- Prevent ignored `CMD` instructions.
+- Encourage a single clear container command per stage.
+
+## Specification
+1. Track whether a `CMD` has been seen in the current stage.
+2. Reset the tracker on each `FROM` instruction.
+3. When encountering a `CMD`:
+   - If one has already been seen, emit `DL4003` for that line.
+   - Otherwise record that a `CMD` is present.
+4. Use the message `Multiple CMD instructions found. If you list more than one CMD then only the last CMD will take effect`.

--- a/docs/rules/DL4004.md
+++ b/docs/rules/DL4004.md
@@ -1,4 +1,16 @@
 # DL4004 - Multiple ENTRYPOINT instructions
 
+## Description
 Listing more than one `ENTRYPOINT` instruction in a single stage means only the last takes effect. Remove redundant `ENTRYPOINT` directives to avoid confusion.
 
+## Goals
+- Ensure each stage defines a single entrypoint.
+- Avoid accidental overriding of earlier `ENTRYPOINT` instructions.
+
+## Specification
+1. Track whether an `ENTRYPOINT` has been seen in the current stage.
+2. Reset the tracker whenever a `FROM` instruction appears.
+3. On encountering an `ENTRYPOINT`:
+   - If one has already been seen, emit `DL4004` for that line.
+   - Otherwise record that an `ENTRYPOINT` exists.
+4. Use the message `Multiple ENTRYPOINT instructions found. If you list more than one ENTRYPOINT then only the last ENTRYPOINT will take effect`.

--- a/docs/rules/DL4005.md
+++ b/docs/rules/DL4005.md
@@ -1,3 +1,14 @@
 # DL4005 - Use SHELL to change the default shell
 
+## Description
 Changing the default shell by linking to `/bin/sh` within a `RUN` instruction is discouraged. Use the `SHELL` directive to specify a different default shell for subsequent commands.
+
+## Goals
+- Encourage explicit shell changes using the `SHELL` instruction.
+- Prevent fragile symlink modifications of `/bin/sh`.
+
+## Specification
+1. Examine every `RUN` instruction.
+2. Tokenize the instruction and split it into individual commands.
+3. If any command begins with `ln` and one of its arguments is `/bin/sh`, emit `DL4005`.
+4. Report the line of the `RUN` instruction with the message `Use SHELL to change the default shell`.

--- a/docs/rules/DL4006.md
+++ b/docs/rules/DL4006.md
@@ -1,4 +1,18 @@
 # DL4006 - Set the SHELL option -o pipefail before RUN with a pipe in it
 
+## Description
 Set the `SHELL` option `-o pipefail` before a `RUN` instruction containing a pipe. Without `pipefail`, errors in piped commands might be masked. If you are using `/bin/sh` in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your `SHELL` to `/bin/ash`, or disable this check.
+
+## Goals
+- Detect failures in any part of a pipeline.
+- Encourage explicit shell configuration when using pipes.
+
+## Specification
+1. Maintain a `pipefail` flag per stage, resetting it on each `FROM` instruction.
+2. When a `SHELL` instruction is encountered:
+   - If the shell is `pwsh`, `powershell`, or `cmd`, set `pipefail` to true (no requirement).
+   - Otherwise set `pipefail` to true only if the shell name is one of `/bin/bash`, `/bin/zsh`, `/bin/ash`, `bash`, `zsh`, or `ash` **and** the instruction includes `-o pipefail`; otherwise set it to false.
+3. For each `RUN` instruction:
+   - If `pipefail` is false and the command contains a `|` character, emit `DL4006`.
+4. Report the line of the offending `RUN` with the message `Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check`.
 

--- a/internal/rules/docs_test.go
+++ b/internal/rules/docs_test.go
@@ -3,10 +3,12 @@
 package rules
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -27,8 +29,15 @@ func TestRuleDocsExist(t *testing.T) {
 			continue
 		}
 		doc := filepath.Join(docDir, name[:len(name)-3]+".md")
-		if _, err := os.Stat(doc); err != nil {
+		content, err := os.ReadFile(doc)
+		if err != nil {
 			t.Errorf("missing documentation for %s", name)
+			continue
+		}
+		headerRe := regexp.MustCompile(fmt.Sprintf(`^#\s+%s\b`, name[:len(name)-3]))
+		lines := strings.Split(string(content), "\n")
+		if len(lines) == 0 || !headerRe.MatchString(lines[0]) {
+			t.Errorf("documentation for %s missing header '# %s'", name, name[:len(name)-3])
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- document DL4000–DL4006 rules with description, goals, and specification sections
- check that rule documentation files exist and match their rule IDs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689f1d3bc3a48332a2ff3ef583f15b26