### PR TITLE
feat: publish docs via GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,34 @@
+# file: .github/workflows/pages.yml
+# (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+
+name: Build and Deploy Docs
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install markdown
+      - name: Build documentation
+        run: |
+          python scripts/build_docs.py --output dist
+      - name: Deploy to gh_pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: gh_pages

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,5 @@ coverage.out
 .idea/
 .vscode/
 build/
-
-coverage.out
+dist/
+__pycache__/

--- a/docs/howto.md
+++ b/docs/howto.md
@@ -1,0 +1,24 @@
+# How To Use docker-lint
+
+## Installation
+
+```bash
+go install github.com/asymmetric-effort/docker-lint/cmd/docker-lint@latest
+```
+
+## Usage
+
+Provide one or more paths or glob patterns (supports `*` and `**`). Matching files are linted and findings are emitted as a JSON array to standard output.
+
+```bash
+docker-lint /path/to/Dockerfile
+docker-lint './**/Dockerfile'
+```
+
+To display the current version:
+
+```bash
+docker-lint --version
+docker-lint -version
+docker-lint version
+```

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,3 @@
+# Introduction
+
+Docker-lint is a minimal linter for Dockerfiles. It parses a Dockerfile using the BuildKit parser, normalizes stages into an intermediate representation, and evaluates rules to report potential issues.

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,3 @@
+# file: scripts/__init__.py
+# (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+"""Utility scripts for docker-lint."""

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -1,0 +1,70 @@
+# file: scripts/build_docs.py
+# (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+
+"""Generate static HTML documentation from Markdown sources."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import List
+
+import markdown
+
+
+def collect_markdown_files(src: Path) -> List[Path]:
+    """Return README.md and all Markdown files under docs/."""
+    files: List[Path] = []
+    readme = src / "README.md"
+    if readme.exists():
+        files.append(readme)
+    docs_dir = src / "docs"
+    if docs_dir.exists():
+        files.extend(sorted(docs_dir.rglob("*.md")))
+    return files
+
+
+def convert_file(md_path: Path) -> str:
+    """Convert a Markdown file to HTML."""
+    text = md_path.read_text(encoding="utf-8")
+    return markdown.markdown(text)
+
+
+def write_html(html: str, dest: Path) -> None:
+    """Write HTML content to the destination path."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(html, encoding="utf-8")
+
+
+def build_site(src: Path, out: Path) -> None:
+    """Generate HTML pages and an index from source Markdown files."""
+    files = collect_markdown_files(src)
+    for md_file in files:
+        html = convert_file(md_file)
+        dest = out / md_file.relative_to(src).with_suffix(".html")
+        write_html(html, dest)
+
+    license_text = (src / "LICENSE").read_text(encoding="utf-8")
+    license_html = markdown.markdown(license_text)
+    write_html(license_html, out / "license.html")
+
+    links = [
+        f'<li><a href="{md.relative_to(src).with_suffix(".html").as_posix()}">{md.stem}</a></li>'
+        for md in files
+    ]
+    links.append('<li><a href="license.html">License</a></li>')
+    index_html = "<ul>\n" + "\n".join(links) + "\n</ul>"
+    write_html(index_html, out / "index.html")
+
+
+def main() -> None:
+    """Entry point for command-line execution."""
+    parser = argparse.ArgumentParser(description="Build documentation site.")
+    parser.add_argument("--src", type=Path, default=Path("."), help="Source directory")
+    parser.add_argument("--output", type=Path, required=True, help="Output directory")
+    args = parser.parse_args()
+    build_site(args.src, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# file: tests/__init__.py
+# (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+"""Test suite for docker-lint."""

--- a/tests/test_build_docs.py
+++ b/tests/test_build_docs.py
@@ -1,0 +1,33 @@
+# file: tests/test_build_docs.py
+# (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+
+"""Tests for documentation site generation."""
+
+from pathlib import Path
+
+from scripts.build_docs import build_site, collect_markdown_files
+
+
+def test_collect_markdown_files(tmp_path: Path) -> None:
+    """collect_markdown_files should find README.md and docs/*.md"""
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "a.md").write_text("# A", encoding="utf-8")
+    (tmp_path / "README.md").write_text("# R", encoding="utf-8")
+    files = collect_markdown_files(tmp_path)
+    expected = {tmp_path / "README.md", tmp_path / "docs" / "a.md"}
+    assert set(files) == expected
+
+
+def test_build_site_generates_html(tmp_path: Path) -> None:
+    """build_site should emit html pages and an index."""
+    src = tmp_path
+    (src / "docs").mkdir()
+    (src / "docs" / "a.md").write_text("# A", encoding="utf-8")
+    (src / "README.md").write_text("# R", encoding="utf-8")
+    (src / "LICENSE").write_text("MIT", encoding="utf-8")
+    out = src / "site"
+    build_site(src, out)
+    assert (out / "README.html").exists()
+    assert (out / "docs" / "a.html").exists()
+    assert (out / "index.html").exists()
+    assert (out / "license.html").exists()


### PR DESCRIPTION
## Summary
- add docs site generator and GitHub Pages workflow
- document introduction and usage of docker-lint
- include tests for documentation builder

## Testing
- `go test ./...`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689f1e208f1c8332b92d203b3cb135f7