### PR TITLE
feat: add icons to docs and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![docker-lint icon](docs/img/docker-linter.png)
+
 # docker-lint
 
 Docker-lint is a minimal linter for Dockerfiles. It parses a Dockerfile using the BuildKit parser, normalizes stages into an intermediate representation, and evaluates a set of rules to report potential issues.

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -6,6 +6,8 @@
 from __future__ import annotations
 
 import argparse
+import os
+import shutil
 from pathlib import Path
 from typing import List
 
@@ -36,17 +38,47 @@ def write_html(html: str, dest: Path) -> None:
     dest.write_text(html, encoding="utf-8")
 
 
+def wrap_html(content: str, out: Path, dest: Path) -> str:
+    """Wrap body content with basic HTML including icon and favicon."""
+    img_path = Path(os.path.relpath(out / "img" / "docker-linter.png", dest.parent)).as_posix()
+    favicon_path = Path(os.path.relpath(out / "img" / "favicon.ico", dest.parent)).as_posix()
+    return (
+        "<!DOCTYPE html>\n<html>\n<head>\n"
+        f'<link rel="icon" href="{favicon_path}">\n'
+        "</head>\n<body>\n"
+        f'<img src="{img_path}" alt="docker-lint icon"/>\n'
+        f"{content}\n"
+        "</body>\n</html>\n"
+    )
+
+
+def copy_static_assets(src: Path, out: Path) -> None:
+    """Copy docs/img assets to the output directory."""
+    img_src = src / "docs" / "img"
+    if not img_src.exists():
+        return
+    targets = [out / "img", out / "docs" / "img"]
+    for dest in targets:
+        dest.mkdir(parents=True, exist_ok=True)
+        for file in img_src.iterdir():
+            if file.is_file():
+                shutil.copy2(file, dest / file.name)
+
+
 def build_site(src: Path, out: Path) -> None:
     """Generate HTML pages and an index from source Markdown files."""
     files = collect_markdown_files(src)
+    copy_static_assets(src, out)
     for md_file in files:
         html = convert_file(md_file)
         dest = out / md_file.relative_to(src).with_suffix(".html")
-        write_html(html, dest)
+        wrapped = wrap_html(html, out, dest)
+        write_html(wrapped, dest)
 
     license_text = (src / "LICENSE").read_text(encoding="utf-8")
     license_html = markdown.markdown(license_text)
-    write_html(license_html, out / "license.html")
+    license_dest = out / "license.html"
+    write_html(wrap_html(license_html, out, license_dest), license_dest)
 
     links = [
         f'<li><a href="{md.relative_to(src).with_suffix(".html").as_posix()}">{md.stem}</a></li>'
@@ -54,7 +86,8 @@ def build_site(src: Path, out: Path) -> None:
     ]
     links.append('<li><a href="license.html">License</a></li>')
     index_html = "<ul>\n" + "\n".join(links) + "\n</ul>"
-    write_html(index_html, out / "index.html")
+    index_dest = out / "index.html"
+    write_html(wrap_html(index_html, out, index_dest), index_dest)
 
 
 def main() -> None:

--- a/tests/test_build_docs.py
+++ b/tests/test_build_docs.py
@@ -19,11 +19,13 @@ def test_collect_markdown_files(tmp_path: Path) -> None:
 
 
 def test_build_site_generates_html(tmp_path: Path) -> None:
-    """build_site should emit html pages and an index."""
+    """build_site should emit html pages, assets, and an index."""
     src = tmp_path
-    (src / "docs").mkdir()
+    (src / "docs" / "img").mkdir(parents=True)
+    (src / "docs" / "img" / "docker-linter.png").write_bytes(b"icon")
+    (src / "docs" / "img" / "favicon.ico").write_bytes(b"icon")
     (src / "docs" / "a.md").write_text("# A", encoding="utf-8")
-    (src / "README.md").write_text("# R", encoding="utf-8")
+    (src / "README.md").write_text("![icon](docs/img/docker-linter.png)\n# R", encoding="utf-8")
     (src / "LICENSE").write_text("MIT", encoding="utf-8")
     out = src / "site"
     build_site(src, out)
@@ -31,3 +33,14 @@ def test_build_site_generates_html(tmp_path: Path) -> None:
     assert (out / "docs" / "a.html").exists()
     assert (out / "index.html").exists()
     assert (out / "license.html").exists()
+    assert (out / "img" / "docker-linter.png").exists()
+    assert (out / "img" / "favicon.ico").exists()
+    assert (out / "docs" / "img" / "docker-linter.png").exists()
+    assert (out / "docs" / "img" / "favicon.ico").exists()
+    readme_html = (out / "README.html").read_text(encoding="utf-8")
+    assert '<img src="img/docker-linter.png"' in readme_html
+    assert '<link rel="icon" href="img/favicon.ico"' in readme_html
+    assert 'src="docs/img/docker-linter.png"' in readme_html
+    nested_html = (out / "docs" / "a.html").read_text(encoding="utf-8")
+    assert '<img src="../img/docker-linter.png"' in nested_html
+    assert '<link rel="icon" href="../img/favicon.ico"' in nested_html


### PR DESCRIPTION
## Summary
- display project logo at top of README
- generate documentation pages with logo and favicon, copying image assets
- test that doc build copies icons and includes them in HTML

## Testing
- `pytest -q`
- `go test ./... -short`


------
https://chatgpt.com/codex/tasks/task_b_689f20b614c88332b97d4b7757336c48