### PR TITLE
Improve documentation site SEO

### DIFF
--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -7,9 +7,22 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
-from typing import List
+from typing import List, Tuple
 
 import markdown
+
+HTML_TEMPLATE = """<!doctype html>
+<html lang=\"en\">
+<head>
+<meta charset=\"utf-8\">
+<title>{title}</title>
+<meta name=\"description\" content=\"{description}\">
+</head>
+<body>
+{content}
+</body>
+</html>
+"""
 
 
 def collect_markdown_files(src: Path) -> List[Path]:
@@ -24,10 +37,35 @@ def collect_markdown_files(src: Path) -> List[Path]:
     return files
 
 
-def convert_file(md_path: Path) -> str:
-    """Convert a Markdown file to HTML."""
+def extract_title(text: str, fallback: str) -> str:
+    """Return the first Markdown heading or fallback."""
+    for line in text.splitlines():
+        if line.startswith("#"):
+            return line.lstrip("#").strip()
+    return fallback
+
+
+def extract_description(text: str) -> str:
+    """Return the first non-heading line for description."""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            return stripped
+    return ""
+
+
+def convert_file(md_path: Path) -> Tuple[str, str, str]:
+    """Convert a Markdown file to HTML and extract metadata."""
     text = md_path.read_text(encoding="utf-8")
-    return markdown.markdown(text)
+    html = markdown.markdown(text)
+    title = extract_title(text, md_path.stem)
+    description = extract_description(text)
+    return html, title, description
+
+
+def render_page(title: str, description: str, body: str) -> str:
+    """Render a full HTML page with SEO tags."""
+    return HTML_TEMPLATE.format(title=title, description=description, content=body)
 
 
 def write_html(html: str, dest: Path) -> None:
@@ -40,20 +78,23 @@ def build_site(src: Path, out: Path) -> None:
     """Generate HTML pages and an index from source Markdown files."""
     files = collect_markdown_files(src)
     for md_file in files:
-        html = convert_file(md_file)
+        body, title, description = convert_file(md_file)
+        page_html = render_page(f"{title} | docker-lint", description, body)
         dest = out / md_file.relative_to(src).with_suffix(".html")
-        write_html(html, dest)
+        write_html(page_html, dest)
 
     license_text = (src / "LICENSE").read_text(encoding="utf-8")
     license_html = markdown.markdown(license_text)
-    write_html(license_html, out / "license.html")
+    license_page = render_page("License | docker-lint", "", license_html)
+    write_html(license_page, out / "license.html")
 
     links = [
         f'<li><a href="{md.relative_to(src).with_suffix(".html").as_posix()}">{md.stem}</a></li>'
         for md in files
     ]
     links.append('<li><a href="license.html">License</a></li>')
-    index_html = "<ul>\n" + "\n".join(links) + "\n</ul>"
+    index_body = "<ul>\n" + "\n".join(links) + "\n</ul>"
+    index_html = render_page("Index | docker-lint", "Documentation index", index_body)
     write_html(index_html, out / "index.html")
 
 

--- a/tests/test_build_docs.py
+++ b/tests/test_build_docs.py
@@ -31,3 +31,17 @@ def test_build_site_generates_html(tmp_path: Path) -> None:
     assert (out / "docs" / "a.html").exists()
     assert (out / "index.html").exists()
     assert (out / "license.html").exists()
+
+
+def test_build_site_adds_seo_metadata(tmp_path: Path) -> None:
+    """Generated pages should include basic SEO meta tags."""
+    src = tmp_path
+    (src / "docs").mkdir()
+    (src / "docs" / "a.md").write_text("# A\n\nAbout A", encoding="utf-8")
+    (src / "README.md").write_text("# R\n\nAbout R", encoding="utf-8")
+    (src / "LICENSE").write_text("MIT", encoding="utf-8")
+    out = src / "site"
+    build_site(src, out)
+    html = (out / "README.html").read_text(encoding="utf-8")
+    assert "<title>R | docker-lint</title>" in html
+    assert '<meta name="description" content="About R"' in html


### PR DESCRIPTION
## Summary
- Wrap documentation pages in HTML templates with SEO-friendly title and description tags
- Extract metadata from markdown files for more informative pages
- Test documentation builder to ensure SEO tags are rendered

## Testing
- `pytest -q`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689f22126cf88332a687297ad9f9a15b