### PR TITLE
docs: document supported platforms and add cross-builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,38 @@ jobs:
         run: |
           go test ./... -run Integration -covermode=atomic -coverpkg=./... -coverprofile=coverage.out
           go tool cover -func=coverage.out | awk '/total:/ { print; if ($3+0 < 80) exit 1 }'
+
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        goos: [linux, windows, darwin]
+        goarch: [amd64, arm64, arm64be]
+        exclude:
+          - goos: windows
+            goarch: arm64be
+          - goos: darwin
+            goarch: arm64be
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
       - name: Build
-        run: go build -trimpath -ldflags "-s -w" ./cmd/docker-lint
+        run: |
+          if go tool dist list | grep -q "${{ matrix.goos }}/${{ matrix.goarch }}"; then
+            GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -trimpath -ldflags "-s -w" -o build/${{ matrix.goos }}_${{ matrix.goarch }}/docker-lint ./cmd/docker-lint
+          else
+            echo "Skipping unsupported platform ${{ matrix.goos }}/${{ matrix.goarch }}"
+          fi
+      - name: Upload artifact
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-lint-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: build/${{ matrix.goos }}_${{ matrix.goarch }}/docker-lint
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Docker-lint is a minimal linter for Dockerfiles. It parses a Dockerfile using the BuildKit parser, normalizes stages into an intermediate representation, and evaluates a set of rules to report potential issues.
 
+## Supported Platforms
+
+See [supported platforms](docs/SUPPORTED_PLATFORMS.md) for all GOOS/GOARCH combinations.
+
 ## Installation
 
 ```bash

--- a/docs/SUPPORTED_PLATFORMS.md
+++ b/docs/SUPPORTED_PLATFORMS.md
@@ -1,0 +1,18 @@
+<!-- file: docs/SUPPORTED_PLATFORMS.md -->
+<!-- (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com -->
+
+# Supported Platforms
+
+The following GOOS/GOARCH combinations are verified in continuous integration:
+
+| GOOS    | GOARCH |
+|---------|--------|
+| linux   | amd64  |
+| linux   | arm64  |
+| windows | amd64  |
+| windows | arm64  |
+| darwin  | amd64  |
+| darwin  | arm64  |
+
+> **Note**
+> The Go toolchain does not currently provide support for `arm64be`, so builds for that architecture are unavailable.


### PR DESCRIPTION
## Summary
- document and link supported GOOS/GOARCH combinations
- cross-compile binaries for linux, windows and darwin in CI

## Testing
- `go mod tidy`
- `test -z "$(gofmt -l .)"`
- `go vet ./...`
- `staticcheck ./...`
- `go test ./... -short -cover`
- `go test ./... -run Integration -covermode=atomic -coverpkg=./... -coverprofile=coverage.out`
- `go tool cover -func=coverage.out | awk '/total:/ { print; if ($3+0 < 80) exit 1 }'`
- `python scripts/build_docs.py --output dist`


------
https://chatgpt.com/codex/tasks/task_b_689f22064d248332a4b881ba3ccb2701