### PR TITLE
docs: add Asymmetric Effort footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,5 @@ make build   # Build the docker-lint binary
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
 
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="docs/img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,3 +33,6 @@ label-schema:
 
 See the [hadolint documentation](https://github.com/hadolint/hadolint#configure) for the meaning of these fields. Docker-lint
 currently honours the `ignored` list and parses the remaining fields for forward compatibility.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/howto.md
+++ b/docs/howto.md
@@ -22,3 +22,6 @@ docker-lint --version
 docker-lint -version
 docker-lint version
 ```
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,3 +1,6 @@
 # Introduction
 
 Docker-lint is a minimal linter for Dockerfiles. It parses a Dockerfile using the BuildKit parser, normalizes stages into an intermediate representation, and evaluates rules to report potential issues.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL1001.md
+++ b/docs/rules/DL1001.md
@@ -11,3 +11,6 @@ Inline `# hadolint ignore=DLxxxx` directives disable lint rules and should be av
 1. Parse the Dockerfile and iterate over each instruction and its preceding comments.
 2. If any comment or instruction contains the case-insensitive substring `hadolint ignore=`, emit `DL1001`.
 3. The finding points to the line where the pragma appears.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3000.md
+++ b/docs/rules/DL3000.md
@@ -9,3 +9,6 @@ Ensure WORKDIR paths are absolute so subsequent commands run in a predictable di
 
 ## Specification
 Inspect each `WORKDIR` instruction. After trimming quotes, if the path does not start with `/`, an environment variable (e.g., `$var`), or a Windows drive letter, emit `DL3000` with message `Use absolute WORKDIR`.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3001.md
+++ b/docs/rules/DL3001.md
@@ -11,3 +11,6 @@ Certain shell commands such as `ssh`, `vim`, `shutdown`, `service`, `ps`, `free`
 1. Inspect each `RUN` instruction.
 2. Split the shell invocation into individual commands.
 3. If any command matches one of: `ssh`, `vim`, `shutdown`, `service`, `ps`, `free`, `top`, `kill`, `mount`, `ifconfig`, emit `DL3001` at the instruction line.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3002.md
+++ b/docs/rules/DL3002.md
@@ -10,3 +10,6 @@ The final `USER` instruction in each stage should not specify a root user (`root
 ## Specification
 1. For each build stage, identify the last `USER` instruction before the next `FROM` or end of file.
 2. If that instruction sets the user to `root`, `0`, or begins with `root:` or `0:`, emit `DL3002` for the line containing the instruction.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3003.md
+++ b/docs/rules/DL3003.md
@@ -11,3 +11,6 @@ Using `cd` in `RUN` instructions is error-prone; prefer the `WORKDIR` instructio
 1. Inspect each `RUN` instruction.
 2. Parse the executed commands.
 3. If any command is `cd`, emit `DL3003` at that line, recommending the use of `WORKDIR`.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3004.md
+++ b/docs/rules/DL3004.md
@@ -11,3 +11,6 @@
 1. Inspect each `RUN` instruction.
 2. Parse the executed commands.
 3. If any command is `sudo`, emit `DL3004` at the instruction line.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3006.md
+++ b/docs/rules/DL3006.md
@@ -12,3 +12,6 @@ Specify an explicit tag or digest for images in `FROM` instructions. Untagged im
 2. If the image is an alias to a previous stage, `scratch`, or starts with a variable (`$`), skip the check.
 3. If the image contains a digest using `@`, the check passes.
 4. Otherwise, split the image on `:`. If no tag is present, emit `DL3006` at the `FROM` line.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3007.md
+++ b/docs/rules/DL3007.md
@@ -11,3 +11,6 @@
 1. For each stage's base image in `FROM`, ignore images with a digest (`@`).
 2. Split the image reference on `:`.
 3. If no tag is present or the tag equals `latest`, emit `DL3007` at the `FROM` line.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3008.md
+++ b/docs/rules/DL3008.md
@@ -13,3 +13,6 @@ Packages installed with `apt-get` or `apt` should be version pinned to ensure de
 3. Tokenize each segment into fields.
 4. When a segment invokes `apt-get` or `apt` followed by `install`, examine subsequent package arguments.
 5. If any package argument that doesn't start with `-` lacks an `=` with a non-empty version value, emit `DL3008` at the instruction line.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3009.md
+++ b/docs/rules/DL3009.md
@@ -13,3 +13,6 @@ After installing packages with `apt-get` or `apt`, remove `/var/lib/apt/lists` i
 3. Track the last segment that performs `apt-get install` or `apt install` and the last segment that removes `/var/lib/apt/lists`.
 4. A cleanup segment deletes `/var/lib/apt/lists` using `rm` with `-r`/`-rf` (any order) or `find` with `-delete`.
 5. If an apt install occurs and no subsequent cleanup segment appears, emit `DL3009` at the instruction line.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3010.md
+++ b/docs/rules/DL3010.md
@@ -13,3 +13,6 @@
 3. Collect the source and destination arguments.
 4. If the destination ends with `/`, check each source path.
 5. If any source has an archive extension (`.tar`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz`, `.tar.xz`, `.txz`), emit `DL3010` at the instruction line suggesting `ADD`.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3011.md
+++ b/docs/rules/DL3011.md
@@ -14,3 +14,6 @@ Ports exposed by `EXPOSE` must fall within the valid TCP/UDP range.
    - Split ranges on `-` and inspect each numeric part.
 3. If a numeric conversion fails, treat the value as valid.
 4. If any numeric part is less than 0 or greater than 65535, emit `DL3011` at the instruction line.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3012.md
+++ b/docs/rules/DL3012.md
@@ -13,3 +13,6 @@ Each build stage may define at most one `HEALTHCHECK`. Additional `HEALTHCHECK` 
 3. Upon encountering a `HEALTHCHECK`:
    - If a `HEALTHCHECK` has already been seen in the current stage, emit `DL3012` at that line.
    - Otherwise, mark that a `HEALTHCHECK` has been seen for this stage.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3013.md
+++ b/docs/rules/DL3013.md
@@ -1,3 +1,6 @@
 # DL3013 - Pin versions in pip
 
 Always pin versions when installing Python packages with `pip` to ensure reproducible builds. Use `pip install <package>==<version>` or install from a requirements file.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3014.md
+++ b/docs/rules/DL3014.md
@@ -4,3 +4,5 @@ Include a non-interactive flag when running `apt-get install` in `RUN`
 instructions. Use `-y`, `--yes`, `--assume-yes`, or an equivalent option such as
 `-qq` to avoid manual prompts during package installation.
 
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3015.md
+++ b/docs/rules/DL3015.md
@@ -2,3 +2,6 @@
 
 The `apt-get install` command installs additional recommended packages by default.
 Use the `--no-install-recommends` flag or set `APT::Install-Recommends=false` to avoid pulling unnecessary dependencies.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3016.md
+++ b/docs/rules/DL3016.md
@@ -3,3 +3,6 @@
 Specify a version, tag, commit, or other explicit reference when installing
 packages with `npm install`. Unpinned dependencies can lead to unpredictable
 builds.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3018.md
+++ b/docs/rules/DL3018.md
@@ -2,3 +2,5 @@
 
 Ensure packages installed via `apk add` are pinned to a version using `=<version>` or installed from `.apk` files to improve build reproducibility.
 
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3019.md
+++ b/docs/rules/DL3019.md
@@ -1,3 +1,6 @@
 # DL3019 - Use --no-cache with apk add
 
 Use the `--no-cache` switch to avoid the need to use `--update` and remove `/var/cache/apk/*` when installing packages with `apk add`.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3020.md
+++ b/docs/rules/DL3020.md
@@ -1,3 +1,6 @@
 # DL3020 - Use COPY instead of ADD for files and folders
 
 Use `COPY` for copying local files or directories. `ADD` should be reserved for remote URLs or archives that need automatic extraction.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3021.md
+++ b/docs/rules/DL3021.md
@@ -1,3 +1,6 @@
 # DL3021 - Ensure destination ends with slash when copying multiple sources
 
 COPY instructions that specify more than two arguments must end the destination path with `/` so the engine treats it as a directory.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3022.md
+++ b/docs/rules/DL3022.md
@@ -2,3 +2,6 @@
 
 When using multi-stage builds, `COPY --from` must reference an alias or index
 that refers to a stage defined earlier in the Dockerfile.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3023.md
+++ b/docs/rules/DL3023.md
@@ -2,3 +2,6 @@
 
 A `COPY --from` flag may not reference the current build stage. Use earlier
 stages or external images instead.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3024.md
+++ b/docs/rules/DL3024.md
@@ -2,3 +2,6 @@
 
 Each stage defined with `FROM ... AS <name>` must use a unique alias name to
 avoid ambiguity in multi-stage builds.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3025.md
+++ b/docs/rules/DL3025.md
@@ -2,3 +2,6 @@
 
 Specify `CMD` and `ENTRYPOINT` arguments using JSON array form to avoid shell
 interpretation issues.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3026.md
+++ b/docs/rules/DL3026.md
@@ -2,3 +2,6 @@
 
 Base images should originate from registries explicitly allowed by policy.
 Any `FROM` instruction using an unapproved registry triggers this rule.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3027.md
+++ b/docs/rules/DL3027.md
@@ -2,3 +2,6 @@
 
 The `apt` tool is intended for interactive use. Use `apt-get` or `apt-cache`
 instead in Dockerfile `RUN` instructions.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3028.md
+++ b/docs/rules/DL3028.md
@@ -2,3 +2,6 @@
 
 When installing gems, specify versions explicitly. Use `gem install <gem>:<version>`
 instead of unpinned installs.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3029.md
+++ b/docs/rules/DL3029.md
@@ -4,3 +4,5 @@ Avoid specifying a fixed platform in `FROM` instructions. Use build environment
 variables like `$BUILDPLATFORM` or `$TARGETPLATFORM` instead of hardcoding
 platforms.
 
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3030.md
+++ b/docs/rules/DL3030.md
@@ -1,3 +1,6 @@
 # DL3030 - Use -y with yum install
 
 Ensure `yum install` commands include the `-y` or `--assumeyes` option to avoid interactive prompts.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3032.md
+++ b/docs/rules/DL3032.md
@@ -18,3 +18,6 @@ unnecessary data from persisting in the image layer.
      - `rm -rf /var/cache/yum/*`.
 4. If a `yum` install occurs without the required cleanup, emit `DL3032` at the
    line of the `RUN` instruction with the message `` `yum clean all` missing after yum command.``
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3033.md
+++ b/docs/rules/DL3033.md
@@ -20,3 +20,6 @@ or module versions to produce deterministic builds.
 3. Ignore flags beginning with `-` when collecting package names.
 4. If any package or module lacks a version specification, emit `DL3033` at the
    `RUN` line with the message ``Specify version with `yum install -y <package>-<version>` ``.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3034.md
+++ b/docs/rules/DL3034.md
@@ -17,3 +17,6 @@ confirmation.
 3. Acceptable flags are `-y`, `-n`, `--non-interactive`, or `--no-confirm`.
 4. If the required flag is missing, emit `DL3034` pointing to the `RUN`
    instruction with the message `Non-interactive switch missing from zypper command: zypper install -y`.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3035.md
+++ b/docs/rules/DL3035.md
@@ -14,3 +14,6 @@ expected versions and should not be used in Docker builds.
    `dist-upgrade` or `dup`.
 3. If such a segment is found, emit `DL3035` at the line of the `RUN`
    instruction with the message `Do not use `zypper dist-upgrade`.`
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3036.md
+++ b/docs/rules/DL3036.md
@@ -16,3 +16,6 @@ small and avoid stale metadata.
    or `zypper cc`.
 4. If a `zypper` install occurs without subsequent cleanup, emit `DL3036` at the
    `RUN` line with the message `` `zypper clean` missing after zypper use.``
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3037.md
+++ b/docs/rules/DL3037.md
@@ -16,3 +16,6 @@ reproducible.
      `<=`, `<`) or ends with `.rpm`.
 3. If any package lacks a version specifier, emit `DL3037` at the line of the
    `RUN` instruction with the message ``Specify version with `zypper install -y <package>=<version>` ``.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3038.md
+++ b/docs/rules/DL3038.md
@@ -16,3 +16,6 @@
      - `--assumeyes`
      - `--assumeyes=<value>`
 4. If the required flag is missing, emit `DL3038` pointing to the line of the `RUN` instruction with the message: `Use the -y switch to avoid manual input dnf install -y <package>`.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3040.md
+++ b/docs/rules/DL3040.md
@@ -38,3 +38,6 @@ RUN dnf install -y jq && dnf clean all
 ```Dockerfile
 RUN microdnf install -y jq && rm -rf /var/cache/dnf
 ```
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3041.md
+++ b/docs/rules/DL3041.md
@@ -1,3 +1,6 @@
 # DL3041 - Avoid dnf upgrade or update in Dockerfiles
 
 Running `dnf upgrade` or `dnf update` (and their `microdnf` equivalents) updates all packages and can break reproducibility. Use a newer base image or install specific packages with pinned versions instead.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3042.md
+++ b/docs/rules/DL3042.md
@@ -1,2 +1,5 @@
 # DL3042 - Combine consecutive RUN instructions that use the same package manager
 Merge related package manager commands into a single RUN to reduce layers and improve caching.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3043.md
+++ b/docs/rules/DL3043.md
@@ -2,3 +2,5 @@
 
 FROM instructions that reference OS-based images must include an explicit version tag instead of floating tags like `latest` or leaving the tag unset. Pinning the operating system version aids reproducibility and security tracking.
 
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3044.md
+++ b/docs/rules/DL3044.md
@@ -1,2 +1,5 @@
 # DL3044 - Specify version with dnf/microdnf install
 Pin all packages when using `dnf install` or `microdnf install` by including an explicit version (e.g., `pkg-1.2.3`).
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3045.md
+++ b/docs/rules/DL3045.md
@@ -2,3 +2,6 @@
 
 Use a digest when copying from an external image with `COPY --from`. Add
 `@sha256:<digest>` to the image reference to ensure reproducible builds.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3046.md
+++ b/docs/rules/DL3046.md
@@ -1,3 +1,6 @@
 # DL3046 - Avoid apk upgrade in Dockerfiles
 
 Avoid `apk upgrade` in Dockerfiles. Upgrade the base image or install specific pinned packages instead.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3047.md
+++ b/docs/rules/DL3047.md
@@ -1,3 +1,6 @@
 # DL3047 - Clean apk cache after installing packages
 
 Clean APK cache after installing packages. Use `apk add --no-cache` or remove `/var/cache/apk/*` in the same RUN instruction.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3048.md
+++ b/docs/rules/DL3048.md
@@ -1,3 +1,6 @@
 # DL3048 - Invalid Label Key
 
 Label keys must use lower-case a–z, 0–9, '.' and '-' only, avoid reserved namespaces, and cannot have leading/trailing or repeated separators.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3050.md
+++ b/docs/rules/DL3050.md
@@ -36,3 +36,6 @@ LABEL org.opencontainers.image.revision="abcd1234"
 ```Dockerfile
 LABEL org.opencontainers.image.source="https://github.com/acme/project"
 ```
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3051.md
+++ b/docs/rules/DL3051.md
@@ -32,3 +32,6 @@ Whitespace-only values are also considered empty:
 FROM scratch
 LABEL foo="   "
 ```
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3052.md
+++ b/docs/rules/DL3052.md
@@ -1,3 +1,6 @@
 # DL3052 - Label is not a valid URL
 
 Labels expected to contain URLs must use valid URL syntax with scheme and host.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3053.md
+++ b/docs/rules/DL3053.md
@@ -1,3 +1,6 @@
 # DL3053 - Label does not conform to RFC3339
 
 Labels designated as timestamps must be formatted according to RFC3339.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3054.md
+++ b/docs/rules/DL3054.md
@@ -1,3 +1,6 @@
 # DL3054 - Label is not a valid SPDX identifier
 
 License labels must match the SPDX identifier pattern.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3055.md
+++ b/docs/rules/DL3055.md
@@ -3,3 +3,5 @@
 Ensure configured build stages use images pinned by digest using
 `@sha256:<digest>` to guarantee reproducible builds.
 
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3056.md
+++ b/docs/rules/DL3056.md
@@ -1,3 +1,6 @@
 # DL3056 - Label does not conform to semantic versioning
 
 Labels representing versions must follow the semantic versioning specification.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3057.md
+++ b/docs/rules/DL3057.md
@@ -1,3 +1,6 @@
 # DL3057 - `HEALTHCHECK` instruction missing
 
 Every build stage should define a `HEALTHCHECK` or inherit from a stage that does.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3058.md
+++ b/docs/rules/DL3058.md
@@ -1,3 +1,6 @@
 # DL3058 - Label is not a valid email address
 
 Labels defined as email addresses must conform to RFC5322 formatting.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3059.md
+++ b/docs/rules/DL3059.md
@@ -1,3 +1,6 @@
 # DL3059 - Multiple consecutive `RUN` instructions
 
 Use a single `RUN` with command chaining instead of many simple consecutive `RUN` layers.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3060.md
+++ b/docs/rules/DL3060.md
@@ -1,3 +1,6 @@
 # DL3060 - `yarn cache clean` missing after `yarn install`
 
 Run commands that execute `yarn install` should also clean the yarn cache in the same layer, unless a BuildKit cache mount is used.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL3061.md
+++ b/docs/rules/DL3061.md
@@ -1,3 +1,6 @@
 # DL3061 - Dockerfile must start with FROM or ARG
 
 Invalid instruction order. Dockerfile must begin with `FROM`, `ARG` or comment.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL4000.md
+++ b/docs/rules/DL4000.md
@@ -11,3 +11,6 @@ The `MAINTAINER` instruction is obsolete. Declare the image author with `LABEL m
 1. Walk each top-level instruction in the Dockerfile AST.
 2. If an instruction's keyword equals `MAINTAINER` (case-insensitive), emit `DL4000`.
 3. Report the line of the `MAINTAINER` instruction with the message `MAINTAINER is deprecated. Use LABEL maintainer="name" instead.`
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL4001.md
+++ b/docs/rules/DL4001.md
@@ -14,3 +14,6 @@ Avoid installing or invoking both `curl` and `wget` in the same stage. Choose a 
    - Detect whether any command starts with `curl` or `wget`.
 3. If a single `RUN` uses both tools or if one tool is used after the other has already appeared in the current stage, emit `DL4001`.
 4. Report the line of the offending `RUN` with the message `Either use Wget or Curl but not both`.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL4003.md
+++ b/docs/rules/DL4003.md
@@ -14,3 +14,6 @@ Multiple `CMD` instructions found. If you list more than one `CMD` then only the
    - If one has already been seen, emit `DL4003` for that line.
    - Otherwise record that a `CMD` is present.
 4. Use the message `Multiple CMD instructions found. If you list more than one CMD then only the last CMD will take effect`.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL4004.md
+++ b/docs/rules/DL4004.md
@@ -14,3 +14,6 @@ Listing more than one `ENTRYPOINT` instruction in a single stage means only the 
    - If one has already been seen, emit `DL4004` for that line.
    - Otherwise record that an `ENTRYPOINT` exists.
 4. Use the message `Multiple ENTRYPOINT instructions found. If you list more than one ENTRYPOINT then only the last ENTRYPOINT will take effect`.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL4005.md
+++ b/docs/rules/DL4005.md
@@ -12,3 +12,6 @@ Changing the default shell by linking to `/bin/sh` within a `RUN` instruction is
 2. Tokenize the instruction and split it into individual commands.
 3. If any command begins with `ln` and one of its arguments is `/bin/sh`, emit `DL4005`.
 4. Report the line of the `RUN` instruction with the message `Use SHELL to change the default shell`.
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/DL4006.md
+++ b/docs/rules/DL4006.md
@@ -16,3 +16,5 @@ Set the `SHELL` option `-o pipefail` before a `RUN` instruction containing a pip
    - If `pipefail` is false and the command contains a `|` character, emit `DL4006`.
 4. Report the line of the offending `RUN` with the message `Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check`.
 
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -65,3 +65,6 @@ The following Hadolint-compatible rules are implemented:
 - [DL4004](DL4004.md) - Multiple ENTRYPOINT instructions
 - [DL4005](DL4005.md) - Use SHELL to change the default shell
 - [DL4006](DL4006.md) - Set the SHELL option -o pipefail before RUN with a pipe in it
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="../img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)


### PR DESCRIPTION
## Summary
- add Asymmetric Effort copyright footer and logo to all Markdown docs
- include 60x60 Asymmetric Effort logo image in docs
- remove duplicate logo file since repository already has this asset

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_689f22a5c2b88332a617e99ab6e2c726