### PR TITLE
Fix ignore pragma parsing with Unicode

### DIFF
--- a/internal/engine/ignore.go
+++ b/internal/engine/ignore.go
@@ -11,6 +11,8 @@ import (
 	"github.com/asymmetric-effort/docker-lint/internal/ir"
 )
 
+const ignoreDirective = "hadolint ignore="
+
 // lineIgnores returns rule IDs to skip keyed by line number.
 //
 // lineIgnores scans the document's AST for `hadolint ignore=` pragmas and
@@ -45,13 +47,14 @@ func addIgnores(m map[int]map[string]struct{}, line int, ids []string) {
 	}
 }
 
-// parseIgnorePragma extracts rule IDs from a comment or instruction.
+// parseIgnorePragma extracts rule IDs from a comment or instruction, case-insensitively.
 func parseIgnorePragma(s string) []string {
-	idx := strings.Index(strings.ToLower(s), "hadolint ignore=")
+	lower := strings.ToLower(s)
+	idx := strings.Index(lower, ignoreDirective)
 	if idx == -1 {
 		return nil
 	}
-	rest := s[idx+len("hadolint ignore="):]
+	rest := lower[idx+len(ignoreDirective):]
 	rest = strings.TrimSpace(rest)
 	fields := strings.FieldsFunc(rest, func(r rune) bool { return r == ',' || r == ' ' || r == '\t' })
 	var ids []string

--- a/internal/engine/ignore_test.go
+++ b/internal/engine/ignore_test.go
@@ -1,0 +1,18 @@
+// file: internal/engine/ignore_test.go
+// (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+package engine
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestParseIgnorePragmaUnicode ensures multi-byte characters before the directive do not break parsing.
+func TestParseIgnorePragmaUnicode(t *testing.T) {
+	input := "# İ hadolint ignore=DL3007, DL2000"
+	got := parseIgnorePragma(input)
+	want := []string{"dl3007", "dl2000"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseIgnorePragma(%q) = %v; want %v", input, got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- handle `hadolint ignore=` pragmas case-insensitively by slicing the lower-cased comment
- add regression test covering multi-byte characters before directives

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689f24a035008332a07aa455ccf0f8ca