### PR TITLE
Add version bump targets and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Copyright (c) 2025 Asymmetric Effort, LLC
 
-.PHONY: lint test build tidy clean all
+.PHONY: lint test build tidy clean all bump_version bump_version/major
 
 all: clean lint test build
 
@@ -31,3 +31,11 @@ tidy:
 clean:
 	@rm -rf build &> /dev/null || true
 	@echo 'make clean: ok'
+
+## Increment the minor version and tag the current commit
+bump_version:
+	python3 scripts/bump_version.py minor
+
+## Increment the major version and tag the current commit
+bump_version/major:
+	python3 scripts/bump_version.py major

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,17 @@
+# Development
+
+Common tasks are managed with [`make`](../Makefile):
+
+| Target | Description |
+| ------ | ----------- |
+| `all` | Run `clean`, `lint`, `test`, and `build` |
+| `bump_version` | Increment the minor version and tag the current commit |
+| `bump_version/major` | Increment the major version and tag the current commit |
+| `lint` | Run static analysis |
+| `test` | Run unit and integration tests |
+| `build` | Build the docker-lint binary |
+| `tidy` | Update Go module dependencies |
+| `clean` | Remove build artifacts |
+
+(c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+[<img src="img/asymmetric-effort.png" alt="Asymmetric Effort logo" width="60" height="60">](https://asymmetric-effort.com/)

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,81 @@
+# file: scripts/bump_version.py
+# (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+"""Utilities for bumping semantic versions and tagging git commits."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from pathlib import Path
+
+VERSION_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+
+
+def get_latest_tag(repo: Path) -> str:
+    """Return the latest tag in *repo* or v0.0.0 if none exists."""
+    result = subprocess.run(
+        ["git", "describe", "--tags", "--abbrev=0"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return "v0.0.0"
+    return result.stdout.strip()
+
+
+def increment_version(tag: str, part: str) -> str:
+    """Increment *tag* by *part* ("minor" or "major")."""
+    match = VERSION_RE.match(tag)
+    if not match:
+        raise ValueError(f"invalid tag: {tag}")
+    major, minor, patch = map(int, match.groups())
+    if part == "major":
+        major += 1
+        minor = 0
+        patch = 0
+    elif part == "minor":
+        minor += 1
+        patch = 0
+    else:
+        raise ValueError("part must be 'major' or 'minor'")
+    return f"v{major}.{minor}.{patch}"
+
+
+def tag_commit(repo: Path, version: str) -> None:
+    """Tag HEAD of *repo* with *version* and push to origin if configured."""
+    subprocess.run(["git", "tag", version], cwd=repo, check=True)
+    remotes = subprocess.run(
+        ["git", "remote"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.split()
+    if "origin" in remotes:
+        subprocess.run(["git", "push", "origin", version], cwd=repo, check=True)
+
+
+def bump_version(repo: Path, part: str) -> str:
+    """Bump the version in *repo* by *part* and tag the current commit."""
+    tag = get_latest_tag(repo)
+    version = increment_version(tag, part)
+    tag_commit(repo, version)
+    return version
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "part",
+        choices=["minor", "major"],
+        nargs="?",
+        default="minor",
+        help="which part of the version to increment",
+    )
+    args = parser.parse_args(argv)
+    repo = Path.cwd()
+    version = bump_version(repo, args.part)
+    print(version)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -1,0 +1,53 @@
+# file: tests/test_bump_version.py
+# (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+"""Tests for the bump_version utility."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+from scripts.bump_version import bump_version, increment_version
+
+
+def init_repo(path: Path) -> None:
+    """Initialize a git repo with a single commit."""
+    subprocess.run(["git", "init"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)
+    (path / "file.txt").write_text("data", encoding="utf-8")
+    subprocess.run(["git", "add", "file.txt"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=path, check=True)
+
+
+def git_tags(path: Path) -> list[str]:
+    """Return a list of tags in *path*."""
+    result = subprocess.run(["git", "tag"], cwd=path, capture_output=True, text=True, check=True)
+    return result.stdout.split()
+
+
+def test_increment_version_minor() -> None:
+    """increment_version should bump the minor part."""
+    assert increment_version("v1.2.3", "minor") == "v1.3.0"
+
+
+def test_increment_version_major() -> None:
+    """increment_version should bump the major part."""
+    assert increment_version("v1.2.3", "major") == "v2.0.0"
+
+
+def test_bump_version_creates_minor_tag(tmp_path: Path) -> None:
+    """bump_version should tag v0.1.0 when no tags exist."""
+    init_repo(tmp_path)
+    version = bump_version(tmp_path, "minor")
+    assert version == "v0.1.0"
+    assert "v0.1.0" in git_tags(tmp_path)
+
+
+def test_bump_version_creates_major_tag(tmp_path: Path) -> None:
+    """bump_version should bump to v1.0.0 from v0.1.0."""
+    init_repo(tmp_path)
+    subprocess.run(["git", "tag", "v0.1.0"], cwd=tmp_path, check=True)
+    version = bump_version(tmp_path, "major")
+    assert version == "v1.0.0"
+    assert "v1.0.0" in git_tags(tmp_path)


### PR DESCRIPTION
## Summary
- add `bump_version` and `bump_version/major` make targets to tag releases
- document Makefile targets in developer guide
- implement version bump utility with tests

## Testing
- `pytest tests`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_689f28d1dd40833299ba5aa89ef07eaf