### PR TITLE
Add package build workflow

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,0 +1,26 @@
+name: packages
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Run tests
+        run: go test ./...
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,63 @@
+version: 2
+project_name: docker-lint
+
+builds:
+  - id: linux
+    main: ./cmd/docker-lint
+    goos: [linux]
+    goarch: [amd64, arm64]
+    env: [CGO_ENABLED=0]
+  - id: darwin
+    main: ./cmd/docker-lint
+    goos: [darwin]
+    goarch: [amd64, arm64]
+    env: [CGO_ENABLED=0]
+  - id: windows
+    main: ./cmd/docker-lint
+    goos: [windows]
+    goarch: [amd64, arm64]
+    env: [CGO_ENABLED=0]
+
+archives:
+  - id: unix
+    builds: [linux, darwin]
+    format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - id: win
+    builds: [windows]
+    format: zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+nfpms:
+  - id: linux
+    package_name: docker-lint
+    builds: [linux]
+    formats: [deb, rpm]
+    file_name_template: "{{ .PackageName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    maintainer: Asymmetric Effort LLC <dev@asymmetric-effort.com>
+    description: Dockerfile linter
+    license: MIT
+
+brews:
+  - name: docker-lint
+    repository:
+      owner: asymmetric-effort
+      name: homebrew-tap
+    ids: [linux, darwin]
+    description: Dockerfile linter
+    homepage: https://github.com/asymmetric-effort/docker-lint
+    install: |
+      bin.install "docker-lint"
+    test: |
+      system "#{bin}/docker-lint", "--version"
+
+chocolateys:
+  - name: docker-lint
+    title: Docker Lint
+    summary: Dockerfile linter
+    description: Dockerfile linter for Windows
+    tags: docker lint
+    authors: Asymmetric Effort LLC
+    project_url: https://github.com/asymmetric-effort/docker-lint
+    license_url: https://github.com/asymmetric-effort/docker-lint/blob/main/LICENSE
+    ids: [windows]

--- a/internal/packaging/naming.go
+++ b/internal/packaging/naming.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2025 Asymmetric Effort, LLC
+
+package packaging
+
+// Name generates a package file name for the given parameters.
+// The format is "docker-lint_<version>_<os>_<arch>.<ext>".
+func Name(version, goos, arch, ext string) string {
+	return "docker-lint_" + version + "_" + goos + "_" + arch + "." + ext
+}

--- a/internal/packaging/naming_test.go
+++ b/internal/packaging/naming_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2025 Asymmetric Effort, LLC
+
+package packaging
+
+import "testing"
+
+// TestName verifies that package file names are generated correctly.
+func TestName(t *testing.T) {
+	cases := []struct {
+		version, goos, arch, ext, expect string
+	}{
+		{"v1.0.0", "linux", "amd64", "deb", "docker-lint_v1.0.0_linux_amd64.deb"},
+		{"v1.0.0", "linux", "arm64", "rpm", "docker-lint_v1.0.0_linux_arm64.rpm"},
+		{"v1.0.0", "windows", "amd64", "nupkg", "docker-lint_v1.0.0_windows_amd64.nupkg"},
+	}
+
+	for _, c := range cases {
+		name := Name(c.version, c.goos, c.arch, c.ext)
+		if name != c.expect {
+			t.Fatalf("expected %s, got %s", c.expect, name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and release packages via GoReleaser
- configure GoReleaser for deb, rpm, brew and chocolatey outputs across supported GOOS/GOARCH targets
- implement tested package name helper

## Testing
- `go test ./...`
- `goreleaser check` *(fails: configuration is invalid: no remote configured to list refs from)*

------
https://chatgpt.com/codex/tasks/task_b_689f2988db4083328b1cb5ef25aed497