### PR TITLE
chore(ci): build packages only on version tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ name: CI
 on:
   push:
     branches: [main]
+    tags:
+      - 'v*'
   pull_request:
 
 permissions:
@@ -37,6 +39,7 @@ jobs:
           go tool cover -func=coverage.out | awk '/total:/ { print; if ($3+0 < 80) exit 1 }'
 
   build:
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     needs: test
     strategy:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,3 +1,5 @@
+# file: .github/workflows/packages.yml
+# (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
 name: packages
 
 on:
@@ -7,6 +9,7 @@ on:
 
 jobs:
   release:
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- run CI build job only on tagged releases
- gate package workflow on version tags

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_689f2ee2916c8332a49ec9fd1268f7f3