### PR TITLE
Sign release artifacts in package workflow

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -20,6 +20,13 @@ jobs:
           go-version: '1.22'
       - name: Run tests
         run: go test ./...
+      - name: Import GPG signing keys
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY_CI_PRIVATE }}
+          GPG_PUBLIC_KEY: ${{ secrets.GPG_SIGNING_KEY_CI_PUBLIC }}
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          echo "$GPG_PUBLIC_KEY" | gpg --batch --import
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+# file: .goreleaser.yml
+# (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
 version: 2
 project_name: docker-lint
 
@@ -61,3 +63,15 @@ chocolateys:
     project_url: https://github.com/asymmetric-effort/docker-lint
     license_url: https://github.com/asymmetric-effort/docker-lint/blob/main/LICENSE
     ids: [windows]
+
+signs:
+  - artifacts: all
+    cmd: gpg
+    args:
+      - "--batch"
+      - "--local-user"
+      - "github@samcaldwell.net"
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"


### PR DESCRIPTION
## Summary
- import CI GPG keys in package workflow
- sign all release artifacts with GoReleaser

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689f4e2b1e288332876b86873770997f