### PR TITLE
Add scheduled GPG key verification

### DIFF
--- a/.github/workflows/check_gpg_keys.yml
+++ b/.github/workflows/check_gpg_keys.yml
@@ -1,0 +1,25 @@
+# file: .github/workflows/check_gpg_keys.yml
+# (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+name: Verify CI GPG keys
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install GnuPG
+        run: sudo apt-get update && sudo apt-get install -y gnupg
+      - name: Verify keys
+        env:
+          GPG_SIGNING_KEY_CI_PRIVATE: ${{ secrets.GPG_SIGNING_KEY_CI_PRIVATE }}
+          GPG_SIGNING_KEY_CI_PUBLIC: ${{ secrets.GPG_SIGNING_KEY_CI_PUBLIC }}
+        run: python3 scripts/check_gpg_keys.py

--- a/scripts/check_gpg_keys.py
+++ b/scripts/check_gpg_keys.py
@@ -1,0 +1,102 @@
+# file: scripts/check_gpg_keys.py
+# (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+"""Utilities to verify CI GPG signing keys."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+SIGNER_KEY_ID = "8528A7AE7B308461"
+
+
+def _run_gpg(args: list[str], data: str | None = None) -> subprocess.CompletedProcess[str]:
+    """Execute gpg with *args* and optional input *data*."""
+    return subprocess.run(
+        ["gpg", "--batch", "--yes", *args],
+        input=data,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+
+def _parse_fingerprint(data: str) -> str:
+    """Extract the first fingerprint from colon-formatted *data*."""
+    for line in data.splitlines():
+        if line.startswith("fpr:"):
+            return line.split(":")[9]
+    raise ValueError("No fingerprint found")
+
+
+def import_key(key_data: str) -> str:
+    """Import *key_data* and return its fingerprint."""
+    info = _run_gpg([
+        "--import-options",
+        "show-only",
+        "--with-colons",
+        "--import",
+    ], key_data).stdout
+    fpr = _parse_fingerprint(info)
+    _run_gpg(["--import"], key_data)
+    return fpr
+
+
+def ensure_signer_key(key_id: str) -> None:
+    """Ensure that *key_id* is present in the keyring."""
+    try:
+        _run_gpg(["--list-keys", key_id])
+    except subprocess.CalledProcessError:
+        _run_gpg(["--keyserver", "hkps://keys.openpgp.org", "--recv-keys", key_id])
+
+
+def is_key_unexpired(fpr: str) -> bool:
+    """Return True if key *fpr* is unexpired."""
+    out = _run_gpg(["--with-colons", "--list-keys", fpr]).stdout
+    for line in out.splitlines():
+        if line.startswith("pub:"):
+            expire = line.split(":")[6]
+            if not expire:
+                return True
+            return int(expire) > int(datetime.now(timezone.utc).timestamp())
+    return False
+
+
+def is_key_signed_by(fpr: str, signer_fpr: str) -> bool:
+    """Return True if key *fpr* is signed by *signer_fpr*."""
+    out = _run_gpg(["--with-colons", "--check-sigs", fpr]).stdout
+    for line in out.splitlines():
+        if line.startswith("sig:"):
+            parts = line.split(":")
+            if len(parts) > 12 and parts[12].upper() == signer_fpr.upper():
+                return True
+    return False
+
+
+def check_gpg_keys(signer_key_id: str = SIGNER_KEY_ID) -> None:
+    """Validate CI signing keys against *signer_key_id*."""
+    pub_key = os.environ.get("GPG_SIGNING_KEY_CI_PUBLIC")
+    priv_key = os.environ.get("GPG_SIGNING_KEY_CI_PRIVATE")
+    if not pub_key or not priv_key:
+        raise SystemExit("Missing key data")
+
+    pub_fpr = import_key(pub_key)
+    priv_fpr = import_key(priv_key)
+    if pub_fpr != priv_fpr:
+        raise SystemExit("Public and private key mismatch")
+
+    ensure_signer_key(signer_key_id)
+    if not is_key_unexpired(pub_fpr):
+        raise SystemExit("Key expired")
+    if not is_key_signed_by(pub_fpr, signer_key_id):
+        raise SystemExit("Key not signed by required signer")
+
+
+if __name__ == "__main__":
+    try:
+        check_gpg_keys()
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(exc.stderr)
+        raise SystemExit(1) from exc

--- a/tests/test_check_gpg_keys.py
+++ b/tests/test_check_gpg_keys.py
@@ -1,0 +1,85 @@
+# file: tests/test_check_gpg_keys.py
+# (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+"""Tests for the check_gpg_keys utility."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from scripts.check_gpg_keys import check_gpg_keys
+
+
+def _run(cmd: list[str], homedir: Path) -> subprocess.CompletedProcess[str]:
+    """Run a gpg command within *homedir*."""
+    env = os.environ | {"GNUPGHOME": str(homedir)}
+    return subprocess.run(cmd, env=env, check=True, capture_output=True, text=True)
+
+
+def _generate_key(email: str, homedir: Path) -> str:
+    """Generate a new key and return its fingerprint."""
+    _run([
+        "gpg",
+        "--batch",
+        "--pinentry-mode=loopback",
+        "--passphrase",
+        "",
+        "--quick-generate-key",
+        email,
+        "default",
+        "default",
+        "never",
+    ], homedir)
+    out = _run(["gpg", "--with-colons", "--list-keys", email], homedir).stdout
+    for line in out.splitlines():
+        if line.startswith("fpr:"):
+            return line.split(":")[9]
+    raise RuntimeError("Fingerprint not found")
+
+
+def _export_keys(email: str, homedir: Path) -> tuple[str, str]:
+    """Return (public, private) ASCII armored keys for *email*."""
+    pub = _run(["gpg", "--armor", "--export", email], homedir).stdout
+    priv = _run(["gpg", "--armor", "--export-secret-keys", email], homedir).stdout
+    return pub, priv
+
+
+def _sign(target_fpr: str, signer_fpr: str, homedir: Path) -> None:
+    """Sign *target_fpr* with *signer_fpr*."""
+    _run([
+        "gpg",
+        "--batch",
+        "--pinentry-mode=loopback",
+        "--passphrase",
+        "",
+        "--quick-sign-key",
+        "--local-user",
+        signer_fpr,
+        target_fpr,
+    ], homedir)
+
+
+@pytest.mark.parametrize("signed", [True, False])
+def test_check_gpg_keys(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, signed: bool) -> None:
+    """check_gpg_keys should validate signature presence."""
+    homedir = tmp_path / "gnupg"
+    homedir.mkdir()
+
+    signer_fpr = _generate_key("signer@example.com", homedir)
+    target_fpr = _generate_key("ci@example.com", homedir)
+    if signed:
+        _sign(target_fpr, signer_fpr, homedir)
+    pub, priv = _export_keys("ci@example.com", homedir)
+
+    monkeypatch.setenv("GPG_SIGNING_KEY_CI_PUBLIC", pub)
+    monkeypatch.setenv("GPG_SIGNING_KEY_CI_PRIVATE", priv)
+    monkeypatch.setenv("GNUPGHOME", str(homedir))
+
+    if signed:
+        check_gpg_keys(signer_fpr)
+    else:
+        with pytest.raises(SystemExit):
+            check_gpg_keys(signer_fpr)


### PR DESCRIPTION
## Summary
- add Python utility to verify CI GPG keys are unexpired and signed by github@samcaldwell.net
- schedule a weekly GitHub Action to run the verification
- test GPG key verification logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689f4f78b92c833285ab4abdb0aeed52