### PR TITLE
feat: add static website

### DIFF
--- a/assets/logo-asymmetric-effort.svg
+++ b/assets/logo-asymmetric-effort.svg
@@ -1,0 +1,5 @@
+<!-- (c) 2025 Asymmetric Effort, LLC. MIT License. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="50" fill="#1c1c1c" />
+  <text x="50" y="55" font-size="18" text-anchor="middle" fill="#fff">AE</text>
+</svg>

--- a/assets/logo-docker-lint.svg
+++ b/assets/logo-docker-lint.svg
@@ -1,0 +1,5 @@
+<!-- (c) 2025 Asymmetric Effort, LLC. MIT License. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#0b72e7" />
+  <text x="50" y="55" font-size="24" text-anchor="middle" fill="#fff">DL</text>
+</svg>

--- a/content/DL_0001.html
+++ b/content/DL_0001.html
@@ -1,0 +1,3 @@
+<!-- (c) 2025 Asymmetric Effort, LLC. MIT License. -->
+<h1>DL_0001</h1>
+<p>Details for DL_0001.</p>

--- a/content/DL_0002.html
+++ b/content/DL_0002.html
@@ -1,0 +1,3 @@
+<!-- (c) 2025 Asymmetric Effort, LLC. MIT License. -->
+<h1>DL_0002</h1>
+<p>Details for DL_0002.</p>

--- a/content/README.html
+++ b/content/README.html
@@ -1,0 +1,3 @@
+<!-- (c) 2025 Asymmetric Effort, LLC. MIT License. -->
+<h1>README</h1>
+<p>This is the README content.</p>

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,49 @@
+/*! (c) 2025 Asymmetric Effort, LLC. MIT License. */
+
+:root{
+  --bg: #ffffff;
+  --fg: #1c1c1c;
+  --muted: #6b7280;
+  --brand: #0b72e7;
+  --border: #e5e7eb;
+  --banner-h: 100px;
+  --radius: 10px;
+  --space: 12px;
+}
+
+html,body{height:100%;}
+body{margin:0;background:var(--bg);color:var(--fg);font:16px/1.45 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;}
+.container{max-width:1200px;margin:0 auto;padding:0 16px;}
+
+#banner{height:var(--banner-h);display:flex;flex-direction:column;justify-content:center;border-bottom:1px solid var(--border);}
+#banner .banner-inner{display:flex;align-items:center;gap:12px;height:100%;}
+#banner .brand-mark{height:64px;width:auto;}
+#banner .site-title{margin:0;font-size:28px;}
+
+.top-nav{display:flex;gap:20px;padding:8px 0;border-top:1px solid var(--border);}
+.top-nav .nav-item{padding:6px 10px;border-radius:8px;text-decoration:none;color:var(--fg);transition:background-color .12s ease, box-shadow .12s ease;}
+.top-nav .nav-item:hover{background:color-mix(in srgb, var(--brand) 12%, transparent);box-shadow:0 0 0 1px color-mix(in srgb, var(--brand) 35%, transparent) inset;}
+.top-nav .nav-item:focus-visible{outline:none;background:color-mix(in srgb, var(--brand) 18%, transparent);box-shadow:0 0 0 2px color-mix(in srgb, var(--brand) 55%, transparent) inset;}
+
+.layout{display:grid;grid-template-columns:280px 1fr;gap:16px;padding:16px 0;}
+
+.navigator{display:flex;flex-direction:column;min-height:60vh;border:1px solid var(--border);border-radius:var(--radius);}
+.nav-header{padding:8px;border-bottom:1px solid var(--border);}
+.nav-logo{height:32px;width:auto;}
+.content-navigator{list-style:none;margin:0;padding:8px;overflow:auto;max-height:calc(80vh - 120px);}
+.content-navigator .nav-link{display:block;padding:6px 8px;border-radius:8px;text-decoration:none;color:var(--fg);transition:background-color .12s ease, box-shadow .12s ease;}
+.content-navigator .nav-link:hover{background:color-mix(in srgb, var(--brand) 12%, transparent);box-shadow:0 0 0 1px color-mix(in srgb, var(--brand) 35%, transparent) inset;}
+.content-navigator .nav-link:focus-visible{outline:none;background:color-mix(in srgb, var(--brand) 18%, transparent);box-shadow:0 0 0 2px color-mix(in srgb, var(--brand) 55%, transparent) inset;}
+
+.nav-footer{margin-top:auto;padding:8px;border-top:1px solid var(--border);display:flex;justify-content:center;}
+.ae-logo{height:32px;width:auto;opacity:.9;}
+
+.content-pane{min-height:60vh;border:1px solid var(--border);border-radius:var(--radius);padding:16px;}
+.prose h1,.prose h2,.prose h3{line-height:1.2}
+
+.footer{padding:16px 0;border-top:1px solid var(--border);color:var(--muted);}
+
+@media (max-width: 900px){
+  .layout{grid-template-columns:1fr;}
+  #banner .site-title{font-size:22px;}
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,55 @@
+<!--
+  (c) 2025 Asymmetric Effort, LLC. MIT License.
+  index.html for Docker Lint static site.
+-->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Docker Lint</title>
+    <link rel="preload" href="/assets/logo-docker-lint.svg" as="image" />
+    <link rel="stylesheet" href="/css/styles.css" />
+  </head>
+  <body>
+    <header id="banner" role="banner" aria-label="Docker Lint">
+      <div class="banner-inner container">
+        <img src="/assets/logo-docker-lint.svg" class="brand-mark" alt="Docker Lint logo" />
+        <h1 class="site-title">Docker Lint</h1>
+      </div>
+      <nav id="top-nav" class="top-nav" aria-label="Primary">
+        <a class="nav-item" href="https://asymmetric-effort.com" rel="noopener" target="_blank">HOME</a>
+        <a class="nav-item" href="https://github.com/asymmetric-effort/docker-lint" rel="noopener" target="_blank">CODE REPO</a>
+      </nav>
+    </header>
+
+    <main id="main" class="layout container" role="main">
+      <aside id="navigator" class="navigator" aria-label="Content Navigator">
+        <div class="nav-header">
+          <img src="/assets/logo-docker-lint.svg" class="nav-logo" alt="Docker Lint" />
+        </div>
+        <ul id="nav-list" class="content-navigator" role="listbox" aria-label="Documents">
+          <li><a class="nav-link" data-src="/content/README.html" href="/content/README.html">README</a></li>
+          <li><a class="nav-link" data-src="/content/DL_0001.html" href="/content/DL_0001.html">DL_0001</a></li>
+          <li><a class="nav-link" data-src="/content/DL_0002.html" href="/content/DL_0002.html">DL_0002</a></li>
+        </ul>
+        <div class="nav-footer">
+          <img src="/assets/logo-asymmetric-effort.svg" class="ae-logo" alt="Asymmetric Effort" />
+        </div>
+      </aside>
+
+      <section id="content" class="content-pane" aria-live="polite" aria-busy="false">
+        <article id="content-article" class="prose">
+          <h2>Welcome to Docker Lint</h2>
+          <p>Select a document from the left to view its contents.</p>
+        </article>
+      </section>
+    </main>
+
+    <footer id="site-footer" class="footer container" role="contentinfo">
+      <small>(c) 2025 Asymmetric Effort, LLC. MIT License.</small>
+    </footer>
+
+    <script src="/js/app.js" defer></script>
+  </body>
+</html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,49 @@
+/*! (c) 2025 Asymmetric Effort, LLC. MIT License. */
+
+(function () {
+  const content = document.getElementById('content');
+  const article = document.getElementById('content-article');
+  const list = document.getElementById('nav-list');
+
+  /**
+   * Toggle the aria-busy state for the content pane.
+   * @param {boolean} busy - True when content is loading.
+   */
+  function setBusy(busy) {
+    content.setAttribute('aria-busy', String(busy));
+  }
+
+  /**
+   * Load HTML from the given URL into the content pane.
+   * @param {string} url - Relative URL of the document to fetch.
+   */
+  async function load(url) {
+    setBusy(true);
+    try {
+      const res = await fetch(url, { credentials: 'omit' });
+      if (!res.ok) throw new Error('HTTP ' + res.status);
+      const html = await res.text();
+      article.innerHTML = html;
+      content.scrollTop = 0;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  list?.addEventListener('click', (e) => {
+    const a = e.target.closest('a.nav-link');
+    if (!a) return;
+    const url = a.dataset.src || a.getAttribute('href');
+    if (!url || url.startsWith('http')) return;
+    e.preventDefault();
+    history.replaceState(null, '', '#' + encodeURIComponent(url));
+    load(url);
+  });
+
+  window.addEventListener('DOMContentLoaded', () => {
+    const hash = decodeURIComponent(location.hash.replace(/^#/, ''));
+    if (hash) {
+      load(hash);
+    }
+  });
+})();

--- a/tests/test_website_structure.py
+++ b/tests/test_website_structure.py
@@ -1,0 +1,38 @@
+# file: tests/test_website_structure.py
+# (c) 2025 Asymmetric Effort, LLC. MIT License.
+
+"""Tests for static Docker Lint website structure."""
+
+from pathlib import Path
+
+import pytest
+from bs4 import BeautifulSoup
+
+
+def test_index_structure() -> None:
+    """index.html should include banner, navigation, and footer."""
+    html = Path("index.html").read_text(encoding="utf-8")
+    soup = BeautifulSoup(html, "html.parser")
+    banner = soup.find("header", id="banner")
+    assert banner is not None
+    assert "Docker Lint" in banner.get_text()
+    top_nav = soup.find("nav", id="top-nav")
+    assert top_nav is not None
+    texts = [a.get_text() for a in top_nav.find_all("a")]
+    assert "HOME" in texts and "CODE REPO" in texts
+    footer = soup.find("footer")
+    assert footer is not None
+    assert "(c) 2025 Asymmetric Effort, LLC. MIT License." in footer.get_text()
+
+
+def test_banner_height_var() -> None:
+    """styles.css defines 100px banner height variable."""
+    css = Path("css/styles.css").read_text(encoding="utf-8")
+    assert "--banner-h: 100px" in css
+
+
+def test_app_aria_busy() -> None:
+    """app.js references aria-busy state."""
+    js = Path("js/app.js").read_text(encoding="utf-8")
+    assert "aria-busy" in js
+


### PR DESCRIPTION
## Summary
- add static Docker Lint website with two-pane navigation
- style site with banner and responsive layout
- load content dynamically via small JS helper
- cover HTML, CSS, and JS with structural tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689f53a75c8c8332ac74aee76fdc3113