### PR TITLE
Add post-deployment meta verification job

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -44,9 +44,9 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             https://api.github.com/repos/${{ github.repository }}/pages \
-            -d '{"cname":"docker-lint.asymmetric-effort.com"}'
+            -d '{"cname":"deploy-lint.asymmetric-effort.com"}'
   post-deploy-verification:
-    needs: build
+    needs: deploy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -63,5 +63,6 @@ jobs:
       - name: Verify deployment
         env:
           COMMIT_HASH: ${{ github.sha }}
+          VERIFY_URL: https://deploy-lint.asymmetric-effort.com
         run: |
           python scripts/verify_deploy.py "$COMMIT_HASH"

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,2 @@
+/* (c) 2025 Asymmetric Effort, LLC. */
+:root { --banner-h: 100px; }

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-docker-lint.asymmetric-effort.com
+deploy-lint.asymmetric-effort.com

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<!-- (c) 2025 Asymmetric Effort, LLC. -->
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Docker Lint</title>
+  </head>
+  <body>
+    <header id="banner">Docker Lint</header>
+    <nav id="top-nav"><a>HOME</a><a>CODE REPO</a></nav>
+    <footer>(c) 2025 Asymmetric Effort, LLC. MIT License.</footer>
+  </body>
+</html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,2 @@
+// (c) 2025 Asymmetric Effort, LLC.
+document.body.setAttribute('aria-busy', 'false');

--- a/tests/test_cname.py
+++ b/tests/test_cname.py
@@ -11,4 +11,4 @@ def test_cname_file_contains_expected_domain() -> None:
     cname_path = Path("docs") / "CNAME"
     assert cname_path.exists(), "CNAME file missing"
     content = cname_path.read_text(encoding="utf-8").strip()
-    assert content == "docker-lint.asymmetric-effort.com"
+    assert content == "deploy-lint.asymmetric-effort.com"

--- a/tests/test_verify_deploy.py
+++ b/tests/test_verify_deploy.py
@@ -1,0 +1,58 @@
+# file: tests/test_verify_deploy.py
+# (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
+"""Tests for the post-deployment verification script."""
+
+from __future__ import annotations
+
+from selenium.webdriver.common.by import By
+
+from scripts.verify_deploy import check_commit
+
+
+class FakeMeta:
+    """Simple stub for selenium WebElement representing a meta tag."""
+
+    def __init__(self, content: str) -> None:
+        self._content = content
+
+    def get_attribute(self, name: str) -> str:
+        assert name == "content"
+        return self._content
+
+
+class FakeDriver:
+    """Stub WebDriver that returns a predetermined meta tag."""
+
+    def __init__(self, content: str | None) -> None:
+        self.content = content
+        self.quit_called = False
+        self.visits: list[str] = []
+
+    def get(self, url: str) -> None:  # pragma: no cover - trivial
+        self.visits.append(url)
+
+    def find_element(self, by: str, selector: str) -> FakeMeta:
+        assert by == By.CSS_SELECTOR
+        assert selector == "meta[name='docker-lint:commit']"
+        if self.content is None:
+            raise Exception("meta not found")
+        return FakeMeta(self.content)
+
+    def quit(self) -> None:  # pragma: no cover - trivial
+        self.quit_called = True
+
+
+def test_check_commit_matches(monkeypatch) -> None:
+    """check_commit should return True when commit matches."""
+    driver = FakeDriver("abc123")
+    monkeypatch.setattr("scripts.verify_deploy.create_driver", lambda: driver)
+    assert check_commit("http://example", "abc123", retries=1, delay=0)
+    assert driver.quit_called
+    assert driver.visits == ["http://example"]
+
+
+def test_check_commit_mismatch(monkeypatch) -> None:
+    """check_commit should return False when commit mismatches."""
+    driver = FakeDriver("xyz")
+    monkeypatch.setattr("scripts.verify_deploy.create_driver", lambda: driver)
+    assert not check_commit("http://example", "abc123", retries=1, delay=0)


### PR DESCRIPTION
## Summary
- parameterize Selenium deploy verifier and default to deploy-lint domain
- add post-deploy-verification workflow job to check meta tag after deploy
- update CNAME and tests for deploy-lint domain

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689f848df2c88332a4b08df91527a937