### PR TITLE
fix: use apiToken for Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Publish to Cloudflare Pages
         uses: cloudflare/pages-action@v1
         with:
-          apiKey: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}
+          apiToken: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
           directory: dist


### PR DESCRIPTION
## Summary
- fix Cloudflare Pages workflow to use the required `apiToken` input

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689f94b55024833294a627bc57a0bb3b