### PR TITLE
chore: integrate codeql workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,11 +5,7 @@
 name: CodeQL
 
 on:
-  push:
-    branches: ["main"]
-  pull_request:
-  schedule:
-    - cron: '0 0 * * 0'
+  workflow_dispatch:
 
 permissions:
   actions: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,11 +33,26 @@ jobs:
           go test ./... -run Integration -covermode=atomic -coverpkg=./... -coverprofile=coverage.out
           go tool cover -func=coverage.out | awk '/total:/ { print; if ($3+0 < 80) exit 1 }'
 
+  sast:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: go
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+
   build:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: 
+    needs:
       - test
+      - sast
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/scheduled-run.yml
+++ b/.github/workflows/scheduled-run.yml
@@ -1,6 +1,6 @@
-# file: .github/workflows/check_gpg_keys.yml
+# file: .github/workflows/scheduled-run.yml
 # (c) 2025 Asymmetric Effort, LLC. scaldwell@asymmetric-effort.com
-name: Verify CI GPG keys
+name: Scheduled Maintenance
 
 on:
   schedule:
@@ -23,3 +23,15 @@ jobs:
           GPG_SIGNING_KEY_CI_PRIVATE: ${{ secrets.GPG_SIGNING_KEY_CI_PRIVATE }}
           GPG_SIGNING_KEY_CI_PUBLIC: ${{ secrets.GPG_SIGNING_KEY_CI_PUBLIC }}
         run: python3 scripts/check_gpg_keys.py
+
+  trigger-codeql:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger CodeQL workflow
+        uses: peter-evans/workflow-dispatch@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          workflow: codeql.yml
+          ref: ${{ github.ref }}


### PR DESCRIPTION
## Summary
- run CodeQL workflow only via `workflow_dispatch`
- schedule weekly job to verify keys and trigger CodeQL scan
- include parallel `sast` CodeQL job in deploy pipeline

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689f9d9fc6a08332b6fb237d8f011762